### PR TITLE
Bump vite from 2.9.9 to 2.9.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "ts-jest": "^27.1.3",
                 "tslib": "^2.3.1",
                 "typescript": "^4.4.4",
-                "vite": "^2.7.2"
+                "vite": "^2.9.13"
             },
             "engines": {
                 "node": ">=16.4.0",
@@ -9345,9 +9345,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "2.9.9",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
-            "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+            "version": "2.9.13",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.13.tgz",
+            "integrity": "sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.14.27",
@@ -16528,9 +16528,9 @@
             }
         },
         "vite": {
-            "version": "2.9.9",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
-            "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+            "version": "2.9.13",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.13.tgz",
+            "integrity": "sha512-AsOBAaT0AD7Mhe8DuK+/kE4aWYFMx/i0ZNi98hJclxb4e0OhQcZYUrvLjIaQ8e59Ui7txcvKMiJC1yftqpQoDw==",
             "dev": true,
             "requires": {
                 "esbuild": "^0.14.27",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
         "typescript": "^4.4.4",
-        "vite": "^2.7.2"
+        "vite": "^2.9.13"
     },
     "dependencies": {
         "@creit-tech/xbull-wallet-connect": "github:Creit-Tech/xBull-Wallet-Connect",


### PR DESCRIPTION
This PR will fix a vulnerability in the current repository's version of vite, by updating the package. 