### PR TITLE
Hotfix/freighter-actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
                   start: npm run dev
               env:
                   VITE_HORIZON_NETWORK_PASSPHRASE: Test SDF Network ; September 2015
+                  VITE_STELLAR_NETWORK: https://horizon-testnet.stellar.org
                   CYPRESS_SIMPLE_SIGNER_PRIVATE_KEY: ${{ secrets.SIMPLE_SIGNER_PRIVATE_KEY }}
     test:
         runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
                   start: npm run dev
               env:
                   VITE_HORIZON_NETWORK_PASSPHRASE: Test SDF Network ; September 2015
-                  VITE_STELLAR_NETWORK: https://horizon-testnet.stellar.org
+                  VITE_STELLAR_NETWORK: ${{ secrets.VITE_STELLAR_NETWORK }}
                   CYPRESS_SIMPLE_SIGNER_PRIVATE_KEY: ${{ secrets.SIMPLE_SIGNER_PRIVATE_KEY }}
     test:
         runs-on: ubuntu-latest

--- a/cypress/integration/ui/connect_spec.ts
+++ b/cypress/integration/ui/connect_spec.ts
@@ -12,6 +12,7 @@ describe('Connect', () => {
         cy.get('.wallet-title').contains('Private Key').as('privateKeyBtn');
         cy.get('.simple-signer-container').as('container');
     });
+
     it("Should check if there's five connect methods", () => {
         cy.get('@privateKeyTitle').should('contain.text', 'Private Key');
         cy.get('@freighterTitle').should('contain.text', 'Freighter');

--- a/cypress/integration/ui/connect_spec.ts
+++ b/cypress/integration/ui/connect_spec.ts
@@ -3,7 +3,7 @@
 describe('Connect', () => {
     beforeEach(() => {
         cy.visit('/connect');
-        cy.wait(300);
+        cy.wait(5000);
         cy.get('.wallet-title').contains('xBull').as('xBullTitle');
         cy.get('.wallet-title').contains('Freighter').as('freighterTitle');
         cy.get('.wallet-title').contains('Albedo').as('albedoTitle');
@@ -32,7 +32,7 @@ describe('Connect', () => {
         cy.get('@privateKeyBtn').click();
         cy.get('@container').should('contain.text', 'Connect');
         cy.get('.cancel-btn').click();
-        cy.wait(100);
+        cy.wait(5000);
         cy.get('@privateKeyTitle').should('contain.text', 'Private Key');
         cy.get('@freighterTitle').should('contain.text', 'Freighter');
         cy.get('@albedoTitle').should('contain.text', 'Albedo');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1",
             "dependencies": {
                 "@creit-tech/xbull-wallet-connect": "github:Creit-Tech/xBull-Wallet-Connect",
-                "@stellar/freighter-api": "^1.1.2",
+                "@stellar/freighter-api": "^1.4.0",
                 "decode-uri-component": "^0.2.2",
                 "json5": "^2.2.2",
                 "stellar-sdk": "^10.1.2",
@@ -1475,9 +1475,9 @@
             }
         },
         "node_modules/@stellar/freighter-api": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-1.1.2.tgz",
-            "integrity": "sha512-2vrPsOn1N3DYTff1763lM1eOy+LNKfkQPH5A3mXlKb3mDUK50wsyM6U03Y1DK/C/9dlMA49FspQ9Es2RF6NpPw=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-1.4.0.tgz",
+            "integrity": "sha512-/ANu1/4mnReUvrSDveKj5XhrnafEssESF/lVdOR1v0ja02kFuhsdsw3anzdz0NvPaPbFgPmjU+v9t9R8KN6r+g=="
         },
         "node_modules/@sveltejs/vite-plugin-svelte": {
             "version": "1.0.0-next.44",
@@ -10765,9 +10765,9 @@
             }
         },
         "@stellar/freighter-api": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-1.1.2.tgz",
-            "integrity": "sha512-2vrPsOn1N3DYTff1763lM1eOy+LNKfkQPH5A3mXlKb3mDUK50wsyM6U03Y1DK/C/9dlMA49FspQ9Es2RF6NpPw=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-1.4.0.tgz",
+            "integrity": "sha512-/ANu1/4mnReUvrSDveKj5XhrnafEssESF/lVdOR1v0ja02kFuhsdsw3anzdz0NvPaPbFgPmjU+v9t9R8KN6r+g=="
         },
         "@sveltejs/vite-plugin-svelte": {
             "version": "1.0.0-next.44",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     },
     "dependencies": {
         "@creit-tech/xbull-wallet-connect": "github:Creit-Tech/xBull-Wallet-Connect",
-        "@stellar/freighter-api": "^1.1.2",
+        "@stellar/freighter-api": "^1.4.0",
         "decode-uri-component": "^0.2.2",
         "json5": "^2.2.2",
         "stellar-sdk": "^10.1.2",

--- a/src/lib/bridge/Bridge.ts
+++ b/src/lib/bridge/Bridge.ts
@@ -1,6 +1,5 @@
 import EventFactory from './EventFactory';
 import type ISimpleSignerEvent from './ISimpleSignerEvent';
-import InvalidMessageError from './InvalidMessageError';
 import type IAvailableWalletsMessage from './availableWalletsMessage/IAvailableWalletsMessage';
 import type { ITransactionMessage } from './transactionMessage/ITransactionMessage';
 
@@ -96,8 +95,6 @@ export default class Bridge {
             this.transactionMessageHandlers.forEach((handler) => handler(message));
             return;
         }
-
-        throw new InvalidMessageError();
     }
 
     private closeWindow() {

--- a/src/lib/bridge/InvalidMessageError.ts
+++ b/src/lib/bridge/InvalidMessageError.ts
@@ -1,1 +1,0 @@
-export default class InvalidMessageError extends Error {}

--- a/src/lib/components/wallets/Wallet.svelte
+++ b/src/lib/components/wallets/Wallet.svelte
@@ -38,9 +38,9 @@
                 </span>
             </div>
 
-            <a class="simple-signer {isInstalled ? '' : 'install-wallet'}" target="_blank" href={wallet.getExtension()}
-                >{isInstalled ? '' : $language.INSTALL}</a
-            >
+            <a class="simple-signer {isInstalled ? '' : 'install-wallet'}" target="_blank" href={wallet.getExtension()}>
+                {isInstalled ? '' : $language.INSTALL}
+            </a>
         </div>
     {/await}
 </div>

--- a/src/lib/wallets/freighter/Freighter.ts
+++ b/src/lib/wallets/freighter/Freighter.ts
@@ -51,14 +51,11 @@ export default class Freighter extends AbstractWallet implements IWallet {
         return Freighter.freighterExtension;
     }
 
-    public override isInstalled(): Promise<boolean> {
-        const freighterPromise: Promise<boolean> = new Promise((resolve) => {
-            if (isConnected()) {
-                resolve(true);
-            } else {
-                resolve(false);
-            }
-        });
-        return freighterPromise;
+    public override async isInstalled(): Promise<boolean> {
+        if (await isConnected()) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/lib/wallets/freighter/Freighter.ts
+++ b/src/lib/wallets/freighter/Freighter.ts
@@ -32,7 +32,7 @@ export default class Freighter extends AbstractWallet implements IWallet {
     }
 
     public override async sign(tx: Transaction): Promise<string> {
-        return signTransaction(tx.toXDR(), this.freighterNetwork);
+        return signTransaction(tx.toXDR(), { network: this.freighterNetwork });
     }
 
     public override getFriendlyName(): string {

--- a/src/lib/wallets/freighter/Freighter.ts
+++ b/src/lib/wallets/freighter/Freighter.ts
@@ -52,10 +52,6 @@ export default class Freighter extends AbstractWallet implements IWallet {
     }
 
     public override async isInstalled(): Promise<boolean> {
-        if (await isConnected()) {
-            return true;
-        } else {
-            return false;
-        }
+        return isConnected();
     }
 }


### PR DESCRIPTION
This pull request addresses an error within the **messageHandler** function. Previously, the function would throw an error if a message did not have the **xdr** or **wallet** property, which caused failures in the Cypress tests. The function was receiving messages from wallets that contained unnecessary properties not required for its intended functionality.

To resolve this issue, the decision was made to remove the error-throwing behavior from the function. Instead, the function will now filter messages based on the specific properties it requires, ignoring any additional properties that may be present. This modification ensures that the messageHandler function operates smoothly without any interruptions caused by irrelevant message properties.