### PR TITLE
feat: WalletConnect Sign

### DIFF
--- a/src/lib/components/logout/Logout.svelte
+++ b/src/lib/components/logout/Logout.svelte
@@ -4,6 +4,7 @@
     import LogoutIcon from '../../../assets/icons/LogoutIcon.svelte';
     import { isLogoutVisible, language } from '../../../store/global';
     import type IStorage from '../../storage/IStorage';
+    import WalletConnect from '../../wallets/walletConnect/WalletConnect';
     import { isLanguageMenuVisible } from '../language/languageStore';
 
     export let storage: IStorage;
@@ -11,6 +12,14 @@
     function toggleMenuVisibility() {
         $isLogoutVisible = !$isLogoutVisible;
         $isLanguageMenuVisible = false;
+    }
+
+    async function logout() {
+        const wallet = new WalletConnect(storage);
+        const startedWallet = await wallet.start();
+        await startedWallet.closeSessions();
+
+        storage.clearStorage();
     }
 </script>
 
@@ -21,7 +30,7 @@
         </button>
         <div class="simple-signer logout-selector-container {$isLogoutVisible ? '' : 'hidden'}">
             <Link to="/connect">
-                <label class="simple-signer logout-active" on:click={() => storage.clearStorage()}>
+                <label class="simple-signer logout-active" on:click={async () => logout()}>
                     <input class="simple-signer hide-circle" type="radio" name="logout" />
                     {$language.LOGOUT}
                 </label>

--- a/src/lib/components/wallets/Wallet.svelte
+++ b/src/lib/components/wallets/Wallet.svelte
@@ -12,14 +12,12 @@
     const dispatch = createEventDispatcher();
 
     async function connect(): Promise<void> {
-        let publicKey: Promise<string> | string | null;
+        let publicKey: string | null;
 
         if (wallet.getName() === PrivateKey.NAME) {
             publicKey = null;
-        } else if (wallet.getName() === WalletConnect.NAME) {
-            publicKey = await wallet.getPublicKey();
         } else {
-            publicKey = wallet.getPublicKey();
+            publicKey = await wallet.getPublicKey();
         }
 
         dispatch('connect', { wallet, publicKey });

--- a/src/lib/components/wallets/Wallets.svelte
+++ b/src/lib/components/wallets/Wallets.svelte
@@ -60,10 +60,11 @@
 
     async function handleWalletConnect(event: CustomEvent): Promise<void> {
         const wallet: IWallet = event.detail.wallet;
+        const publicKey: string = event.detail.publicKey;
+
         if (wallet.getName() === PrivateKey.NAME) {
             $isPrivateKeyFormVisible = true;
         } else {
-            const publicKey = await wallet.getPublicKey();
             dispatchOnConnectEvent(wallet, publicKey);
         }
     }

--- a/src/lib/errors/WalletConnectErrors.ts
+++ b/src/lib/errors/WalletConnectErrors.ts
@@ -1,6 +1,7 @@
 export class NotRunningError extends Error {}
 export class AlreadyRunningError extends Error {}
 export class NoPublicKeyError extends Error {}
-
 export class NoConnectionError extends Error {}
-export class CannotParseError extends Error {}
+export class NoSessionError extends Error {}
+export class MakeRequestError extends Error {}
+export class DisconnectError extends Error {}

--- a/src/lib/service/walletConnect.ts
+++ b/src/lib/service/walletConnect.ts
@@ -51,7 +51,7 @@ export class WallletConnectService {
         this.projectId = projectId;
     }
 
-    public async createWalletConnectClient(params: IWalletConnetCreateClientParams): Promise<ISignClient> {
+    public async createClient(params: IWalletConnetCreateClientParams): Promise<ISignClient> {
         const { name, description, url, icons } = params;
 
         try {
@@ -70,7 +70,7 @@ export class WallletConnectService {
         }
     }
 
-    public async connectWalletConnect(params: IWalletConnetConnectionParams): Promise<SessionTypes.Struct> {
+    public async connect(params: IWalletConnetConnectionParams): Promise<SessionTypes.Struct> {
         const { client, network, methods } = params;
 
         const walletConnectModal = new WalletConnectModal({ projectId: this.projectId });
@@ -113,7 +113,7 @@ export class WallletConnectService {
         }
     }
 
-    public async disconnectWalletConnect(params: IWalletConnectDisconnectParams): Promise<void> {
+    public async disconnect(params: IWalletConnectDisconnectParams): Promise<void> {
         const { client, sessionId } = params;
 
         try {
@@ -130,7 +130,7 @@ export class WallletConnectService {
         }
     }
 
-    public async makeWalletConnectRequest(params: IWalletConnectRequestParams): Promise<{ signedXDR: string }> {
+    public async makeRequest(params: IWalletConnectRequestParams): Promise<{ signedXDR: string }> {
         const { client, xdr, topic, network, method } = params;
 
         const chain =

--- a/src/lib/service/walletConnect.ts
+++ b/src/lib/service/walletConnect.ts
@@ -1,9 +1,10 @@
 import { WalletConnectModal } from '@walletconnect/modal';
 import { SignClient } from '@walletconnect/sign-client';
+import type { EngineTypes } from '@walletconnect/types';
 import type { ISignClient } from '@walletconnect/types/dist/types/sign-client/client';
 import type { SessionTypes } from '@walletconnect/types/dist/types/sign-client/session';
 
-import { CannotParseError, NoConnectionError } from '../errors/WalletConnectErrors';
+import { DisconnectError, MakeRequestError, NoConnectionError } from '../errors/WalletConnectErrors';
 import { StellarNetwork } from '../stellar/StellarNetwork';
 
 export type WalletConnectNetwork = 'testnet' | 'pubnet' | 'public';
@@ -30,16 +31,17 @@ export interface IWalletConnetConnectionParams {
     methods: WalletConnectAllowedMethods[];
 }
 
-export interface IParsedWalletConnectSession {
-    id: string;
-    name: string;
-    description: string;
-    url: string;
-    icons: string;
-    accounts: Array<{
-        network: WalletConnectNetwork;
-        publicKey: string;
-    }>;
+export interface IWalletConnectDisconnectParams {
+    client: ISignClient;
+    sessionId: string;
+}
+
+export interface IWalletConnectRequestParams {
+    client: ISignClient;
+    xdr: string;
+    topic: string;
+    network: WalletConnectNetwork;
+    method: WalletConnectAllowedMethods;
 }
 
 export class WallletConnectService {
@@ -52,15 +54,20 @@ export class WallletConnectService {
     public async createWalletConnectClient(params: IWalletConnetCreateClientParams): Promise<ISignClient> {
         const { name, description, url, icons } = params;
 
-        return SignClient.init({
-            projectId: this.projectId,
-            metadata: {
-                name,
-                url,
-                description,
-                icons,
-            },
-        });
+        try {
+            return SignClient.init({
+                projectId: this.projectId,
+                metadata: {
+                    name,
+                    url,
+                    description,
+                    icons,
+                },
+            });
+        } catch (error) {
+            console.error(error);
+            throw new NoConnectionError();
+        }
     }
 
     public async connectWalletConnect(params: IWalletConnetConnectionParams): Promise<SessionTypes.Struct> {
@@ -71,16 +78,18 @@ export class WallletConnectService {
         const chains =
             network === StellarNetwork.PUBLIC ? [WalletConnectTargetChain.PUBLIC] : [WalletConnectTargetChain.TESTNET];
 
-        try {
-            const { uri, approval } = await client.connect({
-                requiredNamespaces: {
-                    stellar: {
-                        methods,
-                        chains,
-                        events: [],
-                    },
+        const connectParams: EngineTypes.ConnectParams = {
+            requiredNamespaces: {
+                stellar: {
+                    methods,
+                    chains,
+                    events: [],
                 },
-            });
+            },
+        };
+
+        try {
+            const { uri, approval } = await client.connect(connectParams);
 
             return new Promise((resolve, reject) => {
                 if (uri) {
@@ -104,25 +113,41 @@ export class WallletConnectService {
         }
     }
 
-    public parseWalletConnectSession(session: SessionTypes.Struct): IParsedWalletConnectSession {
-        const stellarNamespace = session.namespaces['stellar'];
+    public async disconnectWalletConnect(params: IWalletConnectDisconnectParams): Promise<void> {
+        const { client, sessionId } = params;
 
-        if (!stellarNamespace || !stellarNamespace.accounts.length) {
-            throw new CannotParseError();
+        try {
+            await client.disconnect({
+                topic: sessionId,
+                reason: {
+                    message: 'Session closed',
+                    code: -1,
+                },
+            });
+        } catch (error: unknown) {
+            console.error(error);
+            throw new DisconnectError();
         }
+    }
 
-        const accounts = stellarNamespace.accounts.map((account: string) => ({
-            network: account.split(':')[1] as WalletConnectNetwork,
-            publicKey: account.split(':')[2] as string,
-        }));
+    public async makeWalletConnectRequest(params: IWalletConnectRequestParams): Promise<{ signedXDR: string }> {
+        const { client, xdr, topic, network, method } = params;
 
-        return {
-            id: session.topic,
-            name: session.peer.metadata.name,
-            description: session.peer.metadata.description,
-            url: session.peer.metadata.url,
-            icons: session.peer.metadata.icons[0] as string,
-            accounts,
-        };
+        const chain =
+            network === StellarNetwork.PUBLIC ? WalletConnectTargetChain.PUBLIC : WalletConnectTargetChain.TESTNET;
+
+        try {
+            return client.request({
+                topic: topic,
+                chainId: chain,
+                request: {
+                    method,
+                    params: { xdr },
+                },
+            });
+        } catch (error: unknown) {
+            console.error(error);
+            throw new MakeRequestError();
+        }
     }
 }

--- a/src/lib/storage/IStorage.ts
+++ b/src/lib/storage/IStorage.ts
@@ -1,5 +1,5 @@
 export default interface IStorage {
-    clearStorage(): void;
+    clearStorage(key?: string): void;
     storeItem(key: string, value: string): void;
     getItem(key: string): string | null;
 }

--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -1,8 +1,12 @@
 import type IStorage from './IStorage';
 
 export default class LocalStorage implements IStorage {
-    clearStorage(): void {
-        window.localStorage.clear();
+    clearStorage(key?: string): void {
+        if (key) {
+            window.localStorage.removeItem(key);
+        } else {
+            window.localStorage.clear();
+        }
     }
 
     getItem(key: string): string | null {

--- a/src/lib/wallets/AbstractWallet.ts
+++ b/src/lib/wallets/AbstractWallet.ts
@@ -38,7 +38,7 @@ export default abstract class AbstractWallet implements IWallet {
     }
 
     protected persistWallet(): void {
-        this.storage.clearStorage();
+        this.storage.clearStorage(this.WALLET_STORAGE_KEY);
         this.storage.storeItem(this.WALLET_STORAGE_KEY, this.getName());
     }
 }

--- a/src/lib/wallets/walletConnect/WalletConnect.ts
+++ b/src/lib/wallets/walletConnect/WalletConnect.ts
@@ -1,11 +1,18 @@
+import type { SignClient } from '@walletconnect/sign-client/dist/types/client';
+import type { SessionTypes } from '@walletconnect/types';
 import type { ISignClient } from '@walletconnect/types/dist/types/sign-client/client';
 import type IStorage from 'src/lib/storage/IStorage';
+import type { Transaction } from 'stellar-sdk';
 
 import { WalletConnectIcon } from '../../../assets';
 import { DAPP_BASE_URL, PROJECT_ID_FOR_WALLET_CONNECT } from '../../../constants';
-import { AlreadyRunningError, NoPublicKeyError, NotRunningError } from '../../errors/WalletConnectErrors';
 import {
-    IParsedWalletConnectSession,
+    AlreadyRunningError,
+    NoPublicKeyError,
+    NoSessionError,
+    NotRunningError,
+} from '../../errors/WalletConnectErrors';
+import {
     IWalletConnetConnectionParams,
     WalletConnectAllowedMethods,
     WallletConnectService,
@@ -21,21 +28,15 @@ export default class WalletConnect extends AbstractWallet implements IWallet {
         'Simple Signer provides an easy and secure way to implement log in and transaction signing functionality on your website for the Stellar network.';
     private readonly PROJECT_URL = DAPP_BASE_URL;
     private walletConnectService: WallletConnectService;
-    private signClient?: ISignClient;
-    private activeSession: string | null = null;
+    private signClient?: ISignClient | SignClient;
 
     public static NAME = 'walletConnect';
     public static FRIENDLY_NAME = 'WalletConnect';
-
     public walletConnectNetwork = StellarNetwork.PUBLIC;
 
     constructor(storage: IStorage) {
         super(storage);
         this.walletConnectService = new WallletConnectService(this.PROJECT_ID);
-    }
-
-    private setSession(sessionId: string | null) {
-        this.activeSession = sessionId;
     }
 
     public async start(): Promise<WalletConnect> {
@@ -53,25 +54,36 @@ export default class WalletConnect extends AbstractWallet implements IWallet {
         return this;
     }
 
-    private async connect(params: IWalletConnetConnectionParams): Promise<IParsedWalletConnectSession> {
+    private async connect(params: IWalletConnetConnectionParams): Promise<SessionTypes.Struct> {
         if (!this.signClient) {
             throw new NotRunningError();
         }
 
-        const session = await this.walletConnectService.connectWalletConnect(params);
-        const parseSession = this.walletConnectService.parseWalletConnectSession(session);
-
-        this.setSession(parseSession.id);
-
-        return parseSession;
+        return this.walletConnectService.connectWalletConnect(params);
     }
 
-    private async getSessions(): Promise<IParsedWalletConnectSession[]> {
+    private async closeSession(sessionId: string): Promise<void> {
         if (!this.signClient) {
             throw new NotRunningError();
         }
 
-        return this.signClient.session.values.map(this.walletConnectService.parseWalletConnectSession);
+        await this.walletConnectService.disconnectWalletConnect({
+            client: this.signClient,
+            sessionId,
+        });
+    }
+
+    private async closeSessions(): Promise<void> {
+        if (!this.signClient) {
+            throw new NotRunningError();
+        }
+
+        const sessions = this.signClient.session.getAll();
+
+        if (sessions.length) {
+            const closedSessionsPromises = sessions.map((session) => this.closeSession(session.topic));
+            await Promise.all(closedSessionsPromises);
+        }
     }
 
     public override async getPublicKey(): Promise<string> {
@@ -79,37 +91,46 @@ export default class WalletConnect extends AbstractWallet implements IWallet {
             throw new NotRunningError();
         }
 
-        let publicKey: string | undefined;
+        await this.closeSessions();
 
-        if (this.activeSession) {
-            const activeSessions = await this.getSessions();
+        const session = await this.connect({
+            client: this.signClient,
+            network: this.walletConnectNetwork,
+            methods: [WalletConnectAllowedMethods.SIGN],
+        });
 
-            const targetSession = activeSessions.find((session) => session.id === this.activeSession);
-
-            if (!targetSession) {
-                this.setSession(null);
-            } else {
-                publicKey = targetSession.accounts[0]?.publicKey;
-            }
-        }
-
-        if (!this.activeSession) {
-            const session = await this.connect({
-                client: this.signClient,
-                network: this.walletConnectNetwork,
-                methods: [WalletConnectAllowedMethods.SIGN],
-            });
-
-            this.setSession(session.id);
-
-            publicKey = session.accounts[0]?.publicKey;
-        }
+        const publicKey = session.namespaces['stellar']?.accounts[0]?.split(':')[2];
 
         if (!publicKey) {
             throw new NoPublicKeyError();
         }
 
+        super.persistWallet();
+
         return publicKey;
+    }
+
+    public override async sign(tx: Transaction): Promise<string> {
+        if (!this.signClient) {
+            throw new NotRunningError();
+        }
+
+        const lastKeyIndex = this.signClient.session.getAll().length - 1;
+        const lastSession = this.signClient.session.getAll()[lastKeyIndex];
+
+        if (!lastSession) {
+            throw new NoSessionError();
+        }
+
+        const { signedXDR } = await this.walletConnectService.makeWalletConnectRequest({
+            client: this.signClient,
+            topic: lastSession.topic,
+            network: this.walletConnectNetwork,
+            method: WalletConnectAllowedMethods.SIGN,
+            xdr: tx.toXDR(),
+        });
+
+        return signedXDR;
     }
 
     public override getFriendlyName(): string {

--- a/src/lib/wallets/walletConnect/WalletConnect.ts
+++ b/src/lib/wallets/walletConnect/WalletConnect.ts
@@ -44,7 +44,7 @@ export default class WalletConnect extends AbstractWallet implements IWallet {
             throw new AlreadyRunningError();
         }
 
-        this.signClient = await this.walletConnectService.createWalletConnectClient({
+        this.signClient = await this.walletConnectService.createClient({
             name: this.PROJECT_NAME,
             description: this.PROJECT_DESCRIPTION,
             url: this.PROJECT_URL,
@@ -59,7 +59,7 @@ export default class WalletConnect extends AbstractWallet implements IWallet {
             throw new NotRunningError();
         }
 
-        return this.walletConnectService.connectWalletConnect(params);
+        return this.walletConnectService.connect(params);
     }
 
     private async closeSession(sessionId: string): Promise<void> {
@@ -67,13 +67,13 @@ export default class WalletConnect extends AbstractWallet implements IWallet {
             throw new NotRunningError();
         }
 
-        await this.walletConnectService.disconnectWalletConnect({
+        await this.walletConnectService.disconnect({
             client: this.signClient,
             sessionId,
         });
     }
 
-    private async closeSessions(): Promise<void> {
+    public async closeSessions(): Promise<void> {
         if (!this.signClient) {
             throw new NotRunningError();
         }
@@ -122,7 +122,7 @@ export default class WalletConnect extends AbstractWallet implements IWallet {
             throw new NoSessionError();
         }
 
-        const { signedXDR } = await this.walletConnectService.makeWalletConnectRequest({
+        const { signedXDR } = await this.walletConnectService.makeRequest({
             client: this.signClient,
             topic: lastSession.topic,
             network: this.walletConnectNetwork,

--- a/src/lib/wallets/walletConnect/__tests__/walletConnect.test.ts
+++ b/src/lib/wallets/walletConnect/__tests__/walletConnect.test.ts
@@ -2,8 +2,14 @@
  * @jest-environment jsdom
  */
 import { expect } from '@jest/globals';
+import { Transaction } from 'stellar-sdk';
 
-import { AlreadyRunningError, NotRunningError } from '../../../errors/WalletConnectErrors';
+import {
+    AlreadyRunningError,
+    NoPublicKeyError,
+    NoSessionError,
+    NotRunningError,
+} from '../../../errors/WalletConnectErrors';
 import { WallletConnectService } from '../../../service/walletConnect';
 import LocalStorage from '../../../storage/storage';
 import WalletConnect from '../WalletConnect';
@@ -15,7 +21,7 @@ jest.mock('../../../../constants', () => ({
 const mockServiceMethods = {
     connectWalletConnect: jest.fn(),
     createWalletConnectClient: jest.fn(),
-    parseWalletConnectSession: jest.fn(),
+    makeWalletConnectRequest: jest.fn(),
 };
 jest.mock('../../../service/walletConnect', () => {
     return {
@@ -34,6 +40,7 @@ describe('start', () => {
 
         expect(WallletConnectService).toHaveBeenCalledTimes(1);
     });
+
     it('should run the createWalletConnectClient method when wallet starts and throw error if already running', async () => {
         jest.spyOn(mockServiceMethods, 'createWalletConnectClient').mockResolvedValueOnce({ example: '123' });
 
@@ -64,16 +71,35 @@ describe('getPublicKey', () => {
         }
     });
 
+    it('should throw error if there is no public key', async () => {
+        const ACCOUNT_STR = '';
+
+        jest.spyOn(mockServiceMethods, 'createWalletConnectClient').mockResolvedValueOnce({
+            session: { getAll: () => [] },
+        });
+        jest.spyOn(mockServiceMethods, 'connectWalletConnect').mockResolvedValueOnce({
+            namespaces: { stellar: { accounts: [ACCOUNT_STR] } },
+        });
+
+        const storage = new LocalStorage();
+        const wallet = new WalletConnect(storage);
+        const startedWallet = await wallet.start();
+
+        try {
+            await startedWallet.getPublicKey();
+        } catch (error) {
+            expect(error).toStrictEqual(new NoPublicKeyError());
+        }
+    });
+
     it('should connect if not connected when gettinng public key and return public key', async () => {
-        jest.spyOn(mockServiceMethods, 'createWalletConnectClient').mockResolvedValueOnce({ example: '123' });
-        jest.spyOn(mockServiceMethods, 'connectWalletConnect').mockResolvedValueOnce({ example: '123' });
-        jest.spyOn(mockServiceMethods, 'parseWalletConnectSession').mockResolvedValueOnce({
-            id: '123',
-            name: 'example',
-            description: 'example',
-            url: 'example',
-            icons: 'example',
-            accounts: [{ network: 'example', publicKey: 'examplePublicKey' }],
+        const ACCOUNT_STR = 'stellar:pubnet:examplePublicKey';
+
+        jest.spyOn(mockServiceMethods, 'createWalletConnectClient').mockResolvedValueOnce({
+            session: { getAll: () => [] },
+        });
+        jest.spyOn(mockServiceMethods, 'connectWalletConnect').mockResolvedValueOnce({
+            namespaces: { stellar: { accounts: [ACCOUNT_STR] } },
         });
 
         const storage = new LocalStorage();
@@ -82,7 +108,57 @@ describe('getPublicKey', () => {
         const startedWallet = await wallet.start();
         const publicKey = await startedWallet.getPublicKey();
 
-        expect(mockServiceMethods.parseWalletConnectSession).toBeCalledWith({ example: '123' });
         expect(publicKey).toBe('examplePublicKey');
+    });
+});
+
+describe('sign', () => {
+    const XDR =
+        'AAAAAgAAAABX4uoX9fxBmYuL+JXfoQmb/cImN/E7lc4HPF5r2u0i+QAAAGQAEunYAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAABX4uoX9fxBmYuL+JXfoQmb/cImN/E7lc4HPF5r2u0i+QAAAAAAAAAAAJiWgAAAAAAAAAAA';
+
+    const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+    it('should throw error if wallet is not running', async () => {
+        const storage = new LocalStorage();
+        const wallet = new WalletConnect(storage);
+
+        try {
+            await wallet.sign(new Transaction(XDR, NETWORK_PASSPHRASE));
+        } catch (error) {
+            expect(error).toStrictEqual(new NotRunningError());
+        }
+    });
+
+    it('should throw error if there is no session', async () => {
+        jest.spyOn(mockServiceMethods, 'createWalletConnectClient').mockResolvedValueOnce({
+            session: { getAll: () => [] },
+        });
+
+        const storage = new LocalStorage();
+        const wallet = new WalletConnect(storage);
+        const startedWallet = await wallet.start();
+
+        try {
+            await startedWallet.sign(new Transaction(XDR, NETWORK_PASSPHRASE));
+        } catch (error) {
+            expect(error).toStrictEqual(new NoSessionError());
+        }
+    });
+
+    it('should return a signed XDR', async () => {
+        jest.spyOn(mockServiceMethods, 'createWalletConnectClient').mockResolvedValueOnce({
+            session: { getAll: () => [{}] },
+        });
+
+        jest.spyOn(mockServiceMethods, 'makeWalletConnectRequest').mockResolvedValueOnce({
+            signedXDR: 'exampleSignedXDR',
+        });
+
+        const storage = new LocalStorage();
+        const wallet = new WalletConnect(storage);
+        const startedWallet = await wallet.start();
+        const signedXDR = await startedWallet.sign(new Transaction(XDR, NETWORK_PASSPHRASE));
+
+        expect(signedXDR).toBe('exampleSignedXDR');
     });
 });


### PR DESCRIPTION
Summary:

This pr implements the sign function to the Stellar network wallets supported by the [WalletConnect](https://walletconnect.com/) service ([LOBSTR](https://lobstr.co/) so far).

In turn, the logic of the connect method was modified to disconnect existing sessions before establishing a new connection (if users have not already done so from their devices). Thus, retrieving sessions is avoided and a new one is established each time. The reason for this implementation decision has to do with avoiding incorrect connection flow when more than one connection is established from the same browser.


Finally, WalletConnect class exposes the method for closing sessions used in logout functionality.