### PR TITLE
hotfix: Uppercase Public Key

### DIFF
--- a/src/lib/components/wallets/Wallet.svelte
+++ b/src/lib/components/wallets/Wallet.svelte
@@ -17,7 +17,7 @@
         if (wallet.getName() === PrivateKey.NAME) {
             publicKey = null;
         } else {
-            publicKey = await wallet.getPublicKey();
+            publicKey = (await wallet.getPublicKey()).toUpperCase();
         }
 
         dispatch('connect', { wallet, publicKey });


### PR DESCRIPTION
Summary:

This pr ensures that the connect function in the Wallet component always dispatches an uppercase public key, preventing the case of receiving a lowercase public key from the connected wallet.