### PR TITLE
Feature/implement futurenet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for the [Stellar network](https://stellar.org).
 
 It can be embedded on any website and supports multiple wallets and languages.
 
-## Supported wallets
+## Supported Wallets
 
 <table>
     <thead>
@@ -30,7 +30,7 @@ It can be embedded on any website and supports multiple wallets and languages.
         <td>Freighter</td>
         <td><a href="https://www.freighter.app/">freighter.app</a></td>
         <td>Implemented</td>
-    </tr>     
+    </tr>
     <tr>
         <td>Rabet</td>
         <td><a href="https://rabet.io/">rabet.io</a></td>
@@ -40,7 +40,7 @@ It can be embedded on any website and supports multiple wallets and languages.
         <td>WalletConnect</td>
         <td><a href="https://walletconnect.com/">walletconnect.com</a></td>
         <td>Implemented</td>
-    </tr>    
+    </tr>
     <tr>
         <td>Ledger</td>
         <td><a href="https://ledger.com">ledger.com</a></td>
@@ -49,7 +49,32 @@ It can be embedded on any website and supports multiple wallets and languages.
     </tbody>
 </table>
 
-## Supported languages
+## Supported Networks
+
+<table>
+    <thead>
+        <tr>
+            <th>Network</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>Testnet</td>
+        <td>Implemented</td>
+    </tr>
+    <tr>
+        <td>Public</td>
+        <td>Implemented</td>
+    </tr>
+    <tr>
+        <td>Futurenet</td>
+        <td>Implemented</td>
+    </tr>
+    </tbody>
+</table>
+
+## Supported Languages
 
 See the [documentation on languages](https://github.com/PlutoDAO/simple-stellar-signer/blob/main/docs/languages.md) if
 you want to contribute.
@@ -342,14 +367,14 @@ These wallet values can be used to configure the available wallets on the `/conn
 of
 the `onConnect` event type to indicate which wallet was connected.
 
-| wallet      | type   | value      |
-| ----------- | ------ | ---------- |
-| XBull       | String | xbull      |
-| Albedo      | String | albedo     |
-| Rabet       | String | rabet      |
-| Freighter   | String | freighter  |
-| WalletConnect   | String | walletConnect  |
-| Private Key | String | privateKey |
+| wallet        | type   | value         |
+| ------------- | ------ | ------------- |
+| XBull         | String | xbull         |
+| Albedo        | String | albedo        |
+| Rabet         | String | rabet         |
+| Freighter     | String | freighter     |
+| WalletConnect | String | walletConnect |
+| Private Key   | String | privateKey    |
 
 ## Connect API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@walletconnect/types": "^2.9.2",
                 "decode-uri-component": "^0.2.2",
                 "json5": "^2.2.2",
+                "soroban-client": "0.3.0",
                 "stellar-sdk": "^10.1.2",
                 "util": "^0.12.4"
             },
@@ -8133,9 +8134,9 @@
             }
         },
         "node_modules/node-gyp-build": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+            "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
             "optional": true,
             "bin": {
                 "node-gyp-build": "bin.js",
@@ -9402,6 +9403,39 @@
             },
             "bin": {
                 "sorcery": "bin/index.js"
+            }
+        },
+        "node_modules/soroban-client": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-0.3.0.tgz",
+            "integrity": "sha512-BxwQpW/ZpPaIyZ7mq2dBIRPHzOsp6M9/Co64BPbwW6Kt30NUormIiIKzGFCCWInjk4/9C80jFYeoo5WE7zHHwA==",
+            "dependencies": {
+                "@types/eventsource": "^1.1.2",
+                "@types/node": ">= 8",
+                "@types/randombytes": "^2.0.0",
+                "@types/urijs": "^1.19.6",
+                "axios": "0.25.0",
+                "es6-promise": "^4.2.4",
+                "lodash": "4.17.21",
+                "stellar-base": "8.0.1-soroban.6",
+                "urijs": "^1.19.1"
+            }
+        },
+        "node_modules/soroban-client/node_modules/stellar-base": {
+            "version": "8.0.1-soroban.6",
+            "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-8.0.1-soroban.6.tgz",
+            "integrity": "sha512-LQhre31jzZBNXTaiUfkLlEcC2g2TQOrKJEsY1rbsUv9urlvUsTTIGRmvaw2TH8406FOJZolBtizN/VnZqLqnvg==",
+            "dependencies": {
+                "base32.js": "^0.1.0",
+                "bignumber.js": "^4.0.0",
+                "crc": "^3.5.0",
+                "js-xdr": "^1.1.3",
+                "lodash": "^4.17.21",
+                "sha.js": "^2.3.6",
+                "tweetnacl": "^1.0.3"
+            },
+            "optionalDependencies": {
+                "sodium-native": "^3.3.0"
             }
         },
         "node_modules/source-map": {
@@ -16918,9 +16952,9 @@
             }
         },
         "node-gyp-build": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+            "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
             "optional": true
         },
         "node-int64": {
@@ -17875,6 +17909,39 @@
                 "minimist": "^1.2.0",
                 "sander": "^0.5.0",
                 "sourcemap-codec": "^1.3.0"
+            }
+        },
+        "soroban-client": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-0.3.0.tgz",
+            "integrity": "sha512-BxwQpW/ZpPaIyZ7mq2dBIRPHzOsp6M9/Co64BPbwW6Kt30NUormIiIKzGFCCWInjk4/9C80jFYeoo5WE7zHHwA==",
+            "requires": {
+                "@types/eventsource": "^1.1.2",
+                "@types/node": ">= 8",
+                "@types/randombytes": "^2.0.0",
+                "@types/urijs": "^1.19.6",
+                "axios": "0.25.0",
+                "es6-promise": "^4.2.4",
+                "lodash": "4.17.21",
+                "stellar-base": "8.0.1-soroban.6",
+                "urijs": "^1.19.1"
+            },
+            "dependencies": {
+                "stellar-base": {
+                    "version": "8.0.1-soroban.6",
+                    "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-8.0.1-soroban.6.tgz",
+                    "integrity": "sha512-LQhre31jzZBNXTaiUfkLlEcC2g2TQOrKJEsY1rbsUv9urlvUsTTIGRmvaw2TH8406FOJZolBtizN/VnZqLqnvg==",
+                    "requires": {
+                        "base32.js": "^0.1.0",
+                        "bignumber.js": "^4.0.0",
+                        "crc": "^3.5.0",
+                        "js-xdr": "^1.1.3",
+                        "lodash": "^4.17.21",
+                        "sha.js": "^2.3.6",
+                        "sodium-native": "^3.3.0",
+                        "tweetnacl": "^1.0.3"
+                    }
+                }
             }
         },
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "@walletconnect/types": "^2.9.2",
         "decode-uri-component": "^0.2.2",
         "json5": "^2.2.2",
+        "soroban-client": "0.3.0",
         "stellar-sdk": "^10.1.2",
         "util": "^0.12.4"
     }

--- a/src/lib/service/walletConnect.ts
+++ b/src/lib/service/walletConnect.ts
@@ -13,7 +13,7 @@ import {
 import { StellarNetwork } from '../stellar/StellarNetwork';
 import { WCClient, WCModal } from './lib/walletconnect';
 
-export type WalletConnectNetwork = 'testnet' | 'public';
+export type WalletConnectNetwork = 'testnet' | 'public' | 'futurenet';
 
 export enum WalletConnectTargetChain {
     PUBLIC = 'stellar:pubnet',

--- a/src/lib/stellar/StellarNetwork.ts
+++ b/src/lib/stellar/StellarNetwork.ts
@@ -3,6 +3,7 @@ import { HORIZON_NETWORK_PASSPHRASE, STELLAR_NETWORK } from '../../constants';
 export enum StellarNetwork {
     PUBLIC = 'public',
     TESTNET = 'testnet',
+    FUTURENET = 'futurenet',
 }
 
 export const CURRENT_NETWORK_PASSPHRASE = HORIZON_NETWORK_PASSPHRASE;

--- a/src/lib/wallets/freighter/Freighter.ts
+++ b/src/lib/wallets/freighter/Freighter.ts
@@ -7,7 +7,7 @@ import type IStorage from '../../storage/IStorage';
 import AbstractWallet from '../AbstractWallet';
 import type IWallet from '../IWallet';
 
-type FreighterNetwork = 'PUBLIC' | 'TESTNET';
+type FreighterNetwork = 'PUBLIC' | 'TESTNET' | 'FUTURENET';
 
 export default class Freighter extends AbstractWallet implements IWallet {
     public static NAME = 'freighter';
@@ -20,8 +20,10 @@ export default class Freighter extends AbstractWallet implements IWallet {
 
         if (CURRENT_STELLAR_NETWORK === StellarNetwork.PUBLIC) {
             this.freighterNetwork = StellarNetwork.PUBLIC.toUpperCase() as FreighterNetwork;
-        } else {
+        } else if (CURRENT_STELLAR_NETWORK === StellarNetwork.TESTNET) {
             this.freighterNetwork = StellarNetwork.TESTNET.toUpperCase() as FreighterNetwork;
+        } else {
+            this.freighterNetwork = StellarNetwork.FUTURENET.toLocaleUpperCase() as FreighterNetwork;
         }
     }
 

--- a/src/lib/wallets/freighter/Freighter.ts
+++ b/src/lib/wallets/freighter/Freighter.ts
@@ -23,7 +23,7 @@ export default class Freighter extends AbstractWallet implements IWallet {
         } else if (CURRENT_STELLAR_NETWORK === StellarNetwork.TESTNET) {
             this.freighterNetwork = StellarNetwork.TESTNET.toUpperCase() as FreighterNetwork;
         } else {
-            this.freighterNetwork = StellarNetwork.FUTURENET.toLocaleUpperCase() as FreighterNetwork;
+            this.freighterNetwork = StellarNetwork.FUTURENET.toUpperCase() as FreighterNetwork;
         }
     }
 

--- a/src/lib/wallets/freighter/__test__/freighter.test.ts
+++ b/src/lib/wallets/freighter/__test__/freighter.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { expect } from '@jest/globals';
+import { signTransaction } from '@stellar/freighter-api';
 import SorobanClient from 'soroban-client';
 
+import { StellarNetwork } from '../../../stellar/StellarNetwork';
 import LocalStorage from '../../../storage/storage';
 import Freighter from '../Freighter';
 
@@ -25,22 +27,21 @@ jest.mock('stellar-sdk', () => {
 describe('Freighter management', () => {
     const storage = new LocalStorage();
     let freighter: Freighter;
+    const freighterNetwork = StellarNetwork.FUTURENET.toUpperCase();
 
     beforeEach(() => {
         jest.clearAllMocks();
         freighter = new Freighter(storage);
     });
     it('Should sign a transaction successfully from the Futurenet network', async () => {
-        const { signTransaction } = require('@stellar/freighter-api');
         const signedXdr =
             'AAAAAgAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAGQAATOSAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAAAF9eEAAAAAAAAAAAA=';
-        const tx = SorobanClient.TransactionBuilder.fromXDR(signedXdr, SorobanClient.Networks.STANDALONE);
-
+        const tx = SorobanClient.TransactionBuilder.fromXDR(signedXdr, SorobanClient.Networks.FUTURENET);
         await freighter.sign(tx);
 
-        expect(freighter.freighterNetwork).toEqual('FUTURENET');
+        expect(freighter.freighterNetwork).toEqual(freighterNetwork);
         expect(signTransaction).toHaveBeenCalledWith(signedXdr, {
-            network: 'FUTURENET',
+            network: freighterNetwork,
         });
         expect(signTransaction).toHaveBeenCalledTimes(1);
     });

--- a/src/lib/wallets/freighter/__test__/freighter.test.ts
+++ b/src/lib/wallets/freighter/__test__/freighter.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { expect } from '@jest/globals';
+import SorobanClient from 'soroban-client';
+
+import LocalStorage from '../../../storage/storage';
+import Freighter from '../Freighter';
+
+jest.mock('../../../../constants', () => ({
+    STELLAR_NETWORK: 'futurenet',
+}));
+
+jest.mock('@stellar/freighter-api', () => ({
+    signTransaction: jest.fn(),
+}));
+
+jest.mock('stellar-sdk', () => {
+    return {
+        Transaction: {
+            sign: jest.fn(),
+            toXDR: jest.fn(),
+        },
+    };
+});
+
+describe('Freighter management', () => {
+    const storage = new LocalStorage();
+    let freighter: Freighter;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        freighter = new Freighter(storage);
+    });
+    it('Should sign a transaction successfully from the Futurenet network', async () => {
+        const { signTransaction } = require('@stellar/freighter-api');
+        const signedXdr =
+            'AAAAAgAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAGQAATOSAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAAAF9eEAAAAAAAAAAAA=';
+        const tx = SorobanClient.TransactionBuilder.fromXDR(signedXdr, SorobanClient.Networks.STANDALONE);
+
+        await freighter.sign(tx);
+
+        expect(freighter.freighterNetwork).toEqual('FUTURENET');
+        expect(signTransaction).toHaveBeenCalledWith(signedXdr, {
+            network: 'FUTURENET',
+        });
+        expect(signTransaction).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/wallets/privateKey/__test__/privateKey.test.ts
+++ b/src/lib/wallets/privateKey/__test__/privateKey.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { expect } from '@jest/globals';
+import StellarSdk from 'stellar-sdk';
+import { TextDecoder, TextEncoder } from 'util';
+
+import LocalStorage from '../../../storage/storage';
+import PrivateKey from '../PrivateKey';
+
+global.TextEncoder = TextEncoder;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+global.TextDecoder = TextDecoder;
+
+jest.mock('../../../../constants', () => ({
+    STELLAR_NETWORK: 'futurenet',
+}));
+
+jest.mock('soroban-client', () => {
+    return {
+        Keypair: {
+            fromSecret: jest.fn(),
+        },
+        Transaction: {
+            sign: jest.fn(),
+            toXDR: jest.fn(),
+        },
+    };
+});
+
+const mockTx = {
+    sign: jest.fn(),
+    toXDR: jest.fn(),
+};
+
+jest.mock('stellar-sdk', () => {
+    return {
+        Transaction: jest.fn().mockImplementation(() => mockTx),
+    };
+});
+
+describe('Pivate Key management', () => {
+    const storage = new LocalStorage();
+    let wallet: PrivateKey;
+    const privateKey = 'SANEPI74NFPALZ4JOUTRBOUJGVFOFRKRQT2BZN3UR5ULVEN4FJKT7GRF';
+    const expectedPublicKey = 'FUTURENET';
+    const signedTransaction = 'XDR_SIGNED_FUTURENET';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        wallet = new PrivateKey(storage);
+    });
+    it('Should show a private key from the Futurenet network', async () => {
+        const { Keypair } = require('soroban-client');
+        Keypair.fromSecret.mockReturnValue({
+            publicKey: jest.fn(() => expectedPublicKey),
+        });
+        const publickKey = await wallet.getPublicKey(privateKey);
+
+        expect(publickKey).toEqual(expectedPublicKey);
+    });
+    it('Should sign a transaction successfully from the Futurenet network', async () => {
+        jest.spyOn(mockTx, 'sign').mockImplementationOnce(() => signedTransaction);
+        jest.spyOn(mockTx, 'toXDR').mockImplementationOnce(() => signedTransaction);
+
+        const signedXdr =
+            'AAAAAgAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAGQAATOSAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAAAF9eEAAAAAAAAAAAA=';
+        const networkStandalone = 'Standalone Network ; February 2017';
+        const tx = new StellarSdk.Transaction(signedXdr, networkStandalone);
+
+        const { Keypair } = require('soroban-client');
+        Keypair.fromSecret.mockReturnValue(() => expectedPublicKey);
+
+        const transaction = await wallet.sign(tx);
+
+        expect(transaction).toEqual(signedTransaction);
+        expect(mockTx.sign).toHaveBeenCalledTimes(1);
+        expect(Keypair.fromSecret).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/wallets/privateKey/__test__/privateKey.test.ts
+++ b/src/lib/wallets/privateKey/__test__/privateKey.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { expect } from '@jest/globals';
+import SorobanClient from 'soroban-client';
 import StellarSdk from 'stellar-sdk';
 import { TextDecoder, TextEncoder } from 'util';
 
@@ -23,6 +24,9 @@ jest.mock('soroban-client', () => {
         Transaction: {
             sign: jest.fn(),
             toXDR: jest.fn(),
+        },
+        Networks: {
+            FUTURENET: 'Test SDF Future Network ; October 2022',
         },
     };
 });
@@ -50,8 +54,7 @@ describe('Pivate Key management', () => {
         wallet = new PrivateKey(storage);
     });
     it('Should show a private key from the Futurenet network', async () => {
-        const { Keypair } = require('soroban-client');
-        Keypair.fromSecret.mockReturnValue({
+        SorobanClient.Keypair.fromSecret.mockReturnValue({
             publicKey: jest.fn(() => expectedPublicKey),
         });
         const publickKey = await wallet.getPublicKey(privateKey);
@@ -61,19 +64,16 @@ describe('Pivate Key management', () => {
     it('Should sign a transaction successfully from the Futurenet network', async () => {
         jest.spyOn(mockTx, 'sign').mockImplementationOnce(() => signedTransaction);
         jest.spyOn(mockTx, 'toXDR').mockImplementationOnce(() => signedTransaction);
+        SorobanClient.Keypair.fromSecret.mockReturnValue(() => expectedPublicKey);
 
         const signedXdr =
             'AAAAAgAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAGQAATOSAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAAAF9eEAAAAAAAAAAAA=';
-        const networkStandalone = 'Standalone Network ; February 2017';
-        const tx = new StellarSdk.Transaction(signedXdr, networkStandalone);
-
-        const { Keypair } = require('soroban-client');
-        Keypair.fromSecret.mockReturnValue(() => expectedPublicKey);
+        const tx = new StellarSdk.Transaction(signedXdr, SorobanClient.Networks.FUTURENET);
 
         const transaction = await wallet.sign(tx);
 
         expect(transaction).toEqual(signedTransaction);
         expect(mockTx.sign).toHaveBeenCalledTimes(1);
-        expect(Keypair.fromSecret).toHaveBeenCalledTimes(1);
+        expect(SorobanClient.Keypair.fromSecret).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/lib/wallets/xBull/XBull.ts
+++ b/src/lib/wallets/xBull/XBull.ts
@@ -7,7 +7,7 @@ import type IStorage from '../../storage/IStorage';
 import AbstractWallet from '../AbstractWallet';
 import type IWallet from '../IWallet';
 
-type XBullNetwork = 'public' | 'testnet';
+type XBullNetwork = 'public' | 'testnet' | 'futurenet';
 export default class XBull extends AbstractWallet implements IWallet {
     public static NAME = 'xbull';
     public static FRIENDLY_NAME = 'xBull';
@@ -18,8 +18,10 @@ export default class XBull extends AbstractWallet implements IWallet {
         super(storage);
         if (CURRENT_STELLAR_NETWORK === StellarNetwork.PUBLIC) {
             this.XBullNetwork = StellarNetwork.PUBLIC as XBullNetwork;
-        } else {
+        } else if (CURRENT_STELLAR_NETWORK === StellarNetwork.TESTNET) {
             this.XBullNetwork = StellarNetwork.TESTNET as XBullNetwork;
+        } else {
+            this.XBullNetwork = StellarNetwork.FUTURENET as XBullNetwork;
         }
     }
 
@@ -33,7 +35,7 @@ export default class XBull extends AbstractWallet implements IWallet {
 
     public override async sign(tx: Transaction): Promise<string> {
         const bridge = new xBullWalletConnect();
-        const signedXdr = await bridge.sign({ xdr: tx.toXDR() });
+        const signedXdr = await bridge.sign({ xdr: tx.toXDR(), network: this.XBullNetwork });
         bridge.closeConnections();
         return signedXdr;
     }

--- a/src/lib/wallets/xBull/__test__/xBull.test.ts
+++ b/src/lib/wallets/xBull/__test__/xBull.test.ts
@@ -1,0 +1,54 @@
+import { expect } from '@jest/globals';
+import SorobanClient from 'soroban-client';
+
+import LocalStorage from '../../../storage/storage';
+import XBull from '../XBull';
+
+jest.mock('../../../../constants', () => ({
+    STELLAR_NETWORK: 'futurenet',
+}));
+
+jest.mock('stellar-sdk', () => {
+    return {
+        Transaction: {
+            toXDR: jest.fn(),
+        },
+    };
+});
+
+const mockBridge = {
+    sign: jest.fn(),
+    closeConnections: jest.fn(),
+};
+
+jest.mock('@creit-tech/xbull-wallet-connect', () => {
+    return {
+        xBullWalletConnect: jest.fn().mockImplementationOnce(() => mockBridge),
+    };
+});
+
+describe('xBull management', () => {
+    const storage = new LocalStorage();
+    const xBull = new XBull(storage);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('Should sign a transaction successfully from the Futurenet network', async () => {
+        const responseXdr = 'XDR_FUTURENET';
+        jest.spyOn(mockBridge, 'sign').mockImplementationOnce(() => responseXdr);
+        jest.spyOn(mockBridge, 'closeConnections').mockReturnValue(() => '');
+
+        const signedXdr =
+            'AAAAAgAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAGQAATOSAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAAAF9eEAAAAAAAAAAAA=';
+        const tx = SorobanClient.TransactionBuilder.fromXDR(signedXdr, SorobanClient.Networks.STANDALONE);
+
+        const result = await xBull.sign(tx);
+
+        expect(result).toBe(responseXdr);
+        expect(xBull.XBullNetwork).toEqual('futurenet');
+        expect(mockBridge.sign).toHaveBeenCalledTimes(1);
+        expect(mockBridge.sign).toHaveBeenLastCalledWith({ xdr: signedXdr, network: 'futurenet' });
+    });
+});

--- a/src/lib/wallets/xBull/__test__/xBull.test.ts
+++ b/src/lib/wallets/xBull/__test__/xBull.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@jest/globals';
 import SorobanClient from 'soroban-client';
 
+import { StellarNetwork } from '../../../stellar/StellarNetwork';
 import LocalStorage from '../../../storage/storage';
 import XBull from '../XBull';
 
@@ -30,6 +31,7 @@ jest.mock('@creit-tech/xbull-wallet-connect', () => {
 describe('xBull management', () => {
     const storage = new LocalStorage();
     const xBull = new XBull(storage);
+    const xBullNetwork = StellarNetwork.FUTURENET;
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -42,13 +44,13 @@ describe('xBull management', () => {
 
         const signedXdr =
             'AAAAAgAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAGQAATOSAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAAAF9eEAAAAAAAAAAAA=';
-        const tx = SorobanClient.TransactionBuilder.fromXDR(signedXdr, SorobanClient.Networks.STANDALONE);
+        const tx = SorobanClient.TransactionBuilder.fromXDR(signedXdr, SorobanClient.Networks.FUTURENET);
 
         const result = await xBull.sign(tx);
 
         expect(result).toBe(responseXdr);
-        expect(xBull.XBullNetwork).toEqual('futurenet');
+        expect(xBull.XBullNetwork).toEqual(xBullNetwork);
         expect(mockBridge.sign).toHaveBeenCalledTimes(1);
-        expect(mockBridge.sign).toHaveBeenLastCalledWith({ xdr: signedXdr, network: 'futurenet' });
+        expect(mockBridge.sign).toHaveBeenLastCalledWith({ xdr: signedXdr, network: xBullNetwork });
     });
 });


### PR DESCRIPTION
# Summary

- Add Futurenet in `PrivateKey` to login and sign transactions.
- Add a file to test the implementation in `PrivateKey`.
- Add Futurenet to sign transactions in `Freighter` and `xBull` wallets.
- Add a file for each wallet to test the signatures.
- Add Futurenet in `WalletConnectNetwork` so I don't have type errors with `StellarNetwoks`.

# Details

- Add Futurenet in wallets that support the network and by private key.

# Evidence

### Login and sign transaction with private key
![privateKey](https://github.com/PlutoDAO/simple-stellar-signer/assets/60760903/56e3f53c-e90b-4fc5-89d4-fa319fdbe15c)
### Sign transaction with Freighter
![freighter](https://github.com/PlutoDAO/simple-stellar-signer/assets/60760903/0a8687d5-a01c-4ed3-8478-b7ea5a77d0ff)
### Sign transaction with xBull
![xbull](https://github.com/PlutoDAO/simple-stellar-signer/assets/60760903/8f2ebf58-c3b9-4b3a-82eb-2a98d377c567)
