### PR TITLE
Add trustline verification

### DIFF
--- a/cypress/fixtures/payment.json
+++ b/cypress/fixtures/payment.json
@@ -1,5 +1,5 @@
 {
-    "destinationAccount": "GCECUYXE32PPYKPVYOSILACOCUGMEZSDO7GYERC2GKAG2HM34BLMMOMB",
+    "destinationAccount": "GCAGLYWX5SWMKOE537BN3PNCCENL2QAG5H35P55GH5BPQW7QGYIRV6NZ",
     "amountToSend": 100,
     "assetCode": "native",
     "issuer": "none"

--- a/src/lib/i18n/ITranslation.ts
+++ b/src/lib/i18n/ITranslation.ts
@@ -74,6 +74,7 @@ export interface ITranslation {
     NETWORK_FEE: string;
     NETWORK: string;
     NOT_AUTHORIZED_TO_TRANSACT: string;
+    NO_TRUSTLINE: string;
     OFFER_ID: string;
     OPERATION_ACCOUNT_MERGE: string;
     OPERATION_ACCOUNT_TRUST: string;

--- a/src/lib/i18n/languages/english.json
+++ b/src/lib/i18n/languages/english.json
@@ -74,6 +74,7 @@
     "NETWORK_FEE": "Network Fee:",
     "NETWORK": "Network",
     "NOT_AUTHORIZED_TO_TRANSACT": "Authorization: The account is not authorized to transact with the asset",
+    "NO_TRUSTLINE": "The recipient hasn't established a trustline with the asset.",
     "OFFER_ID": "Offer ID:",
     "OPERATION_ACCOUNT_MERGE": "Account Merge",
     "OPERATION_ACCOUNT_TRUST": "Trust",

--- a/src/lib/i18n/languages/spanish.json
+++ b/src/lib/i18n/languages/spanish.json
@@ -74,6 +74,7 @@
     "NETWORK_FEE": "Comisión de la red:",
     "NETWORK": "Red",
     "NOT_AUTHORIZED_TO_TRANSACT": "Autorización: La cuenta no está autorizada para realizar transacciones con el activo",
+    "NO_TRUSTLINE": "El destinatario no estableció una línea de confianza con el activo.",
     "OFFER_ID": "ID de la Oferta:",
     "OPERATION_ACCOUNT_MERGE": "Combinar cuentas",
     "OPERATION_ACCOUNT_TRUST": "Establecer línea de confianza",

--- a/src/lib/stellar/Payment.ts
+++ b/src/lib/stellar/Payment.ts
@@ -3,6 +3,24 @@ import { Asset, BASE_FEE, Operation, TransactionBuilder } from 'stellar-sdk';
 import { CURRENT_NETWORK_PASSPHRASE } from './StellarNetwork';
 import { server } from './utils';
 
+export async function checkTrustline(receiver: string, assetCode: string, issuer: string) {
+    const account = await server.loadAccount(receiver);
+
+    for (const balance of account.balances) {
+        if (assetCode === 'native') {
+            if ('asset_type' in balance && balance.asset_type === 'native') {
+                return true;
+            }
+        } else if ('asset_code' in balance && 'asset_issuer' in balance) {
+            if (balance.asset_code === assetCode && balance.asset_issuer === issuer) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 export async function createPaymentTransaction(
     publicKey: string,
     receiver: string,

--- a/src/lib/stellar/Payment.ts
+++ b/src/lib/stellar/Payment.ts
@@ -4,21 +4,21 @@ import { CURRENT_NETWORK_PASSPHRASE } from './StellarNetwork';
 import { server } from './utils';
 
 export async function checkTrustline(receiver: string, assetCode: string, issuer: string) {
-    const account = await server.loadAccount(receiver);
+    try {
+        const account = await server.loadAccount(receiver);
 
-    for (const balance of account.balances) {
-        if (assetCode === 'native') {
-            if ('asset_type' in balance && balance.asset_type === 'native') {
-                return true;
-            }
-        } else if ('asset_code' in balance && 'asset_issuer' in balance) {
-            if (balance.asset_code === assetCode && balance.asset_issuer === issuer) {
+        for (const balance of account.balances) {
+            if (
+                (assetCode === 'native' && balance.asset_type === 'native') ||
+                ('asset_code' in balance && balance.asset_code === assetCode && balance.asset_issuer === issuer)
+            ) {
                 return true;
             }
         }
+        return false;
+    } catch (error) {
+        throw new Error(JSON.stringify(error));
     }
-
-    return false;
 }
 
 export async function createPaymentTransaction(


### PR DESCRIPTION
# Summary

Implemented a function that checks if the recipient user has established trustlines with the asset to be received. A message will be displayed in the popup when attempting to make the payment.

# Evidence

![image](https://github.com/ScaleMote/simple-stellar-signer/assets/70997096/4f3b319d-abc9-4e79-aa2b-6e09d33b3d36)

