### PR TITLE
Added space after "NETWORK:" in Payment.svelte

### DIFF
--- a/src/routes/payment/Payment.svelte
+++ b/src/routes/payment/Payment.svelte
@@ -127,6 +127,7 @@
             <div class="simple-signer tx-network-container">
                 <div class="simple-signer pay-network-container">
                     <p>{$language.NETWORK}:</p>
+                    &nbsp;
                     <p class="simple-signer pay-network-text">{CURRENT_STELLAR_NETWORK}</p>
                 </div>
             </div>


### PR DESCRIPTION
# Summary

Added space after NETWORK string in Payment.svelte.

# Evidence

![imagen](https://github.com/ScaleMote/simple-stellar-signer/assets/70997096/834bc552-739a-4df1-9913-1013f0128dec)
