### PR TITLE
Fix/rename invokehostfunction prop

### DIFF
--- a/src/lib/components/transaction/operations/invokeHostFunction/InvokeHostFunctionComponent.ts
+++ b/src/lib/components/transaction/operations/invokeHostFunction/InvokeHostFunctionComponent.ts
@@ -29,7 +29,7 @@ export default class InvokeHostFunctionComponent extends AbstractOperationCompon
             operationItems: [
                 { title: 'SOURCE_ACCOUNT', value: operation.source || tx.source, translatedValue: 'YOUR_ACCOUNT' },
                 { title: 'CONTRACT_ID', value: contractID },
-                { title: 'FUNCTION_TYPE', value: funcTitle },
+                { title: 'FUNCTION_NAME', value: funcTitle },
                 (funcParameter.description ? true : undefined) && {
                     title: 'DESCRIPTION',
                     value: [funcParameter.description!],

--- a/src/lib/i18n/ITranslation.ts
+++ b/src/lib/i18n/ITranslation.ts
@@ -40,6 +40,7 @@ export interface ITranslation {
     FEE_BUMP: string;
     FEE: string;
     FROM: string;
+    FUNCTION_NAME: string;
     FUNCTION_TYPE: string;
     GO_TO_CONNECT: string;
     GO_TO_SIGN: string;

--- a/src/lib/i18n/languages/english.json
+++ b/src/lib/i18n/languages/english.json
@@ -40,6 +40,7 @@
     "FEE_BUMP": "FEE BUMP",
     "FEE": "Fee",
     "FROM": "From:",
+    "FUNCTION_NAME": "Function name:",    
     "FUNCTION_TYPE": "Function type:",
     "GO_TO_CONNECT": "Go to Connect",
     "GO_TO_SIGN": "Go to Sign",

--- a/src/lib/i18n/languages/english.json
+++ b/src/lib/i18n/languages/english.json
@@ -40,7 +40,7 @@
     "FEE_BUMP": "FEE BUMP",
     "FEE": "Fee",
     "FROM": "From:",
-    "FUNCTION_NAME": "Function name:",    
+    "FUNCTION_NAME": "Function name:",
     "FUNCTION_TYPE": "Function type:",
     "GO_TO_CONNECT": "Go to Connect",
     "GO_TO_SIGN": "Go to Sign",

--- a/src/lib/i18n/languages/spanish.json
+++ b/src/lib/i18n/languages/spanish.json
@@ -40,6 +40,7 @@
     "FEE_BUMP": "FEE BUMP",
     "FEE": "Comisión",
     "FROM": "De:",
+    "FUNCTION_NAME": "Nombre de la función:",
     "FUNCTION_TYPE": "Tipo de función:",
     "GO_TO_CONNECT": "Ir a Conectar",
     "GO_TO_SIGN": "Ir a Firmar",


### PR DESCRIPTION
# Summary

This PR changes the FUNCTION_TYPE prop from InvokeHostfunctionComponent to FUNCTION_NAME

# Details

* Add FUNCTION_NAME to the  app's dictionary
* Change function type prop to function name at InvokeHostfunctionComponent

