### PR TITLE
Bump StellarSDK and XBull dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
             "name": "simple-stellar-signer",
             "version": "0.1",
             "dependencies": {
-                "@creit-tech/xbull-wallet-connect": "github:Creit-Tech/xBull-Wallet-Connect",
+                "@creit.tech/xbull-wallet-connect": "^0.3.0",
                 "@lobstrco/signer-extension-api": "^1.0.0-beta.0",
                 "@stellar/freighter-api": "^1.4.0",
-                "@stellar/stellar-sdk": "^12.3.0",
+                "@stellar/stellar-sdk": "^13.1.0",
                 "@walletconnect/modal": "^2.6.1",
                 "@walletconnect/sign-client": "^2.9.2",
                 "@walletconnect/types": "^2.9.2",
@@ -65,12 +65,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.24.2",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -184,53 +185,132 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-            "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/@babel/generator": {
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+            "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.26.5",
+                "@babel/types": "^7.26.5",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/@babel/traverse": {
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+            "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.5",
+                "@babel/parser": "^7.26.5",
+                "@babel/template": "^7.25.9",
+                "@babel/types": "^7.26.5",
+                "debug": "^4.3.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz",
-            "integrity": "sha512-t5s2BeSWIghhFRPh9XMn6EIGmvn8Lmw5RVASJzkIx1mSemubQQBNIZiQD7WzaFmaHIrjAec4x8z9Yx8SjJ1/LA==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.16.7",
-                "@babel/helper-module-imports": "^7.16.7",
-                "@babel/helper-simple-access": "^7.17.7",
-                "@babel/helper-split-export-declaration": "^7.16.7",
-                "@babel/helper-validator-identifier": "^7.16.7",
-                "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.17.12",
-                "@babel/types": "^7.17.12"
+                "@babel/helper-module-imports": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms/node_modules/@babel/generator": {
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+            "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.26.5",
+                "@babel/types": "^7.26.5",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms/node_modules/@babel/traverse": {
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+            "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.5",
+                "@babel/parser": "^7.26.5",
+                "@babel/template": "^7.25.9",
+                "@babel/types": "^7.26.5",
+                "debug": "^4.3.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms/node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
-            "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
             "dev": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-simple-access": {
-            "version": "7.17.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
-            "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.17.0"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -248,27 +328,27 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-            "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -288,97 +368,14 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/highlight": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-            "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.5",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
-        },
-        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@babel/parser": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+            "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
             "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.26.5"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -534,12 +531,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.17.12.tgz",
-            "integrity": "sha512-TYY0SXFiO31YXtNg3HtFwNJHjLsAyIIhAhNWkQ5whPPS7HWUFlg9z0Ta4qAQNjQbP1wsSt/oKkmZ/4/WWdMUpw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+            "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.17.12"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -561,14 +558,14 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/parser": "^7.24.0",
-                "@babel/types": "^7.24.0"
+                "@babel/code-frame": "^7.25.9",
+                "@babel/parser": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -611,14 +608,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+            "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -640,13 +636,17 @@
                 "node": ">=0.1.90"
             }
         },
-        "node_modules/@creit-tech/xbull-wallet-connect": {
-            "version": "0.1.0",
-            "resolved": "git+ssh://git@github.com/Creit-Tech/xBull-Wallet-Connect.git#bf6725307a5de7e513aa67fa6b8bdbf58797af1d",
+        "node_modules/@creit.tech/xbull-wallet-connect": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.3.0.tgz",
+            "integrity": "sha512-pByi0bTAWd2ZdolVtkXcAU1DYTtz/cJc/IkRUz9x9/1NsFVyrM4UxE8tHgVZ3mwrJ4josoDwYP957ynQw195YQ==",
             "dependencies": {
                 "rxjs": "^7.5.5",
                 "tweetnacl": "^1.0.3",
                 "tweetnacl-util": "^0.15.1"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@cypress/request": {
@@ -1228,17 +1228,9 @@
             }
         },
         "node_modules/@lit-labs/ssr-dom-shim": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
-            "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
-        },
-        "node_modules/@lit/reactive-element": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-            "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.0.0"
-            }
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+            "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ=="
         },
         "node_modules/@lobstrco/signer-extension-api": {
             "version": "1.0.0-beta.0",
@@ -1246,78 +1238,79 @@
             "integrity": "sha512-16V34W9MyTgunGvgkzv1JmV+k59OjNWCrNOH+KH+6vWamcGDGBnFhvRgGEarEhINYITMGkdqEvaEy7qTD5s5cw=="
         },
         "node_modules/@motionone/animation": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
-            "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
+            "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
             "dependencies": {
-                "@motionone/easing": "^10.15.1",
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
+                "@motionone/easing": "^10.18.0",
+                "@motionone/types": "^10.17.1",
+                "@motionone/utils": "^10.18.0",
                 "tslib": "^2.3.1"
             }
         },
         "node_modules/@motionone/dom": {
-            "version": "10.16.2",
-            "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
-            "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.18.0.tgz",
+            "integrity": "sha512-bKLP7E0eyO4B2UaHBBN55tnppwRnaE3KFfh3Ps9HhnAkar3Cb69kUCJY9as8LrccVYKgHA+JY5dOQqJLOPhF5A==",
             "dependencies": {
-                "@motionone/animation": "^10.15.1",
-                "@motionone/generators": "^10.15.1",
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
+                "@motionone/animation": "^10.18.0",
+                "@motionone/generators": "^10.18.0",
+                "@motionone/types": "^10.17.1",
+                "@motionone/utils": "^10.18.0",
                 "hey-listen": "^1.0.8",
                 "tslib": "^2.3.1"
             }
         },
         "node_modules/@motionone/easing": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
-            "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
+            "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
             "dependencies": {
-                "@motionone/utils": "^10.15.1",
+                "@motionone/utils": "^10.18.0",
                 "tslib": "^2.3.1"
             }
         },
         "node_modules/@motionone/generators": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
-            "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
+            "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
             "dependencies": {
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
+                "@motionone/types": "^10.17.1",
+                "@motionone/utils": "^10.18.0",
                 "tslib": "^2.3.1"
             }
         },
         "node_modules/@motionone/svelte": {
-            "version": "10.16.2",
-            "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.2.tgz",
-            "integrity": "sha512-38xsroKrfK+aHYhuQlE6eFcGy0EwrB43Q7RGjF73j/kRUTcLNu/LAaKiLLsN5lyqVzCgTBVt4TMT/ShWbTbc5Q==",
+            "version": "10.16.4",
+            "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.4.tgz",
+            "integrity": "sha512-zRVqk20lD1xqe+yEDZhMYgftsuHc25+9JSo+r0a0OWUJFocjSV9D/+UGhX4xgJsuwB9acPzXLr20w40VnY2PQA==",
             "dependencies": {
-                "@motionone/dom": "^10.16.2",
+                "@motionone/dom": "^10.16.4",
                 "tslib": "^2.3.1"
             }
         },
         "node_modules/@motionone/types": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
-            "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
+            "version": "10.17.1",
+            "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
+            "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A=="
         },
         "node_modules/@motionone/utils": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
-            "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
+            "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
             "dependencies": {
-                "@motionone/types": "^10.15.1",
+                "@motionone/types": "^10.17.1",
                 "hey-listen": "^1.0.8",
                 "tslib": "^2.3.1"
             }
         },
         "node_modules/@motionone/vue": {
-            "version": "10.16.2",
-            "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.2.tgz",
-            "integrity": "sha512-7/dEK/nWQXOkJ70bqb2KyNfSWbNvWqKKq1C8juj+0Mg/AorgD8O5wE3naddK0G+aXuNMqRuc4jlsYHHWHtIzVw==",
+            "version": "10.16.4",
+            "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.4.tgz",
+            "integrity": "sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==",
+            "deprecated": "Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion",
             "dependencies": {
-                "@motionone/dom": "^10.16.2",
+                "@motionone/dom": "^10.16.4",
                 "tslib": "^2.3.1"
             }
         },
@@ -1544,42 +1537,25 @@
             "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
             "license": "Apache-2.0"
         },
-        "node_modules/@stellar/stellar-base": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-10.0.1.tgz",
-            "integrity": "sha512-BDbx7VHOEQh+4J3Q+gStNXgPaNckVFmD4aOlBBGwxlF6vPFmVnW8IoJdkX7T58zpX55eWI6DXvEhDBlrqTlhAQ==",
-            "dependencies": {
-                "@stellar/js-xdr": "^3.0.1",
-                "base32.js": "^0.1.0",
-                "bignumber.js": "^9.1.2",
-                "buffer": "^6.0.3",
-                "sha.js": "^2.3.6",
-                "tweetnacl": "^1.0.3"
-            },
-            "optionalDependencies": {
-                "sodium-native": "^4.0.1"
-            }
-        },
         "node_modules/@stellar/stellar-sdk": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
-            "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
-            "license": "Apache-2.0",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.1.0.tgz",
+            "integrity": "sha512-ARQkUdyGefXdTgwSF0eONkzv/geAqUfyfheJ9Nthz6GAr5b41fNwWW9UtE8JpXC4IpvE3t5elIUN5hKJzASN9w==",
             "dependencies": {
-                "@stellar/stellar-base": "^12.1.1",
-                "axios": "^1.7.7",
+                "@stellar/stellar-base": "^13.0.1",
+                "axios": "^1.7.9",
                 "bignumber.js": "^9.1.2",
                 "eventsource": "^2.0.2",
+                "feaxios": "^0.0.23",
                 "randombytes": "^2.1.0",
                 "toml": "^3.0.0",
                 "urijs": "^1.19.1"
             }
         },
         "node_modules/@stellar/stellar-sdk/node_modules/@stellar/stellar-base": {
-            "version": "12.1.1",
-            "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-            "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
-            "license": "Apache-2.0",
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.0.1.tgz",
+            "integrity": "sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==",
             "dependencies": {
                 "@stellar/js-xdr": "^3.1.2",
                 "base32.js": "^0.1.0",
@@ -1589,7 +1565,7 @@
                 "tweetnacl": "^1.0.3"
             },
             "optionalDependencies": {
-                "sodium-native": "^4.1.1"
+                "sodium-native": "^4.3.0"
             }
         },
         "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -1922,9 +1898,9 @@
             }
         },
         "node_modules/@types/trusted-types": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-            "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "node_modules/@types/yargs": {
             "version": "16.0.4",
@@ -2166,24 +2142,25 @@
             }
         },
         "node_modules/@walletconnect/core": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.2.tgz",
-            "integrity": "sha512-VARMPAx8sIgodeyngDHbealP3B621PQqjqKsByFUTOep8ZI1/R/20zU+cmq6j9RCrL+kLKZcrZqeVzs8Z7OlqQ==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.11.2.tgz",
+            "integrity": "sha512-bB4SiXX8hX3/hyBfVPC5gwZCXCl+OPj+/EDVM71iAO3TDsh78KPbrVAbDnnsbHzZVHlsMohtXX3j5XVsheN3+g==",
             "dependencies": {
                 "@walletconnect/heartbeat": "1.2.1",
                 "@walletconnect/jsonrpc-provider": "1.0.13",
                 "@walletconnect/jsonrpc-types": "1.0.3",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
-                "@walletconnect/jsonrpc-ws-connection": "1.0.13",
-                "@walletconnect/keyvaluestorage": "^1.0.2",
+                "@walletconnect/jsonrpc-ws-connection": "1.0.14",
+                "@walletconnect/keyvaluestorage": "^1.1.1",
                 "@walletconnect/logger": "^2.0.1",
                 "@walletconnect/relay-api": "^1.0.9",
                 "@walletconnect/relay-auth": "^1.0.4",
                 "@walletconnect/safe-json": "^1.0.2",
                 "@walletconnect/time": "^1.0.2",
-                "@walletconnect/types": "2.9.2",
-                "@walletconnect/utils": "2.9.2",
+                "@walletconnect/types": "2.11.2",
+                "@walletconnect/utils": "2.11.2",
                 "events": "^3.3.0",
+                "isomorphic-unfetch": "3.1.0",
                 "lodash.isequal": "4.5.0",
                 "uint8arrays": "^3.1.0"
             }
@@ -2275,47 +2252,33 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/jsonrpc-ws-connection": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
-            "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
+            "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
             "dependencies": {
                 "@walletconnect/jsonrpc-utils": "^1.0.6",
                 "@walletconnect/safe-json": "^1.0.2",
                 "events": "^3.3.0",
-                "tslib": "1.14.1",
                 "ws": "^7.5.1"
             }
         },
-        "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
         "node_modules/@walletconnect/keyvaluestorage": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.2.tgz",
-            "integrity": "sha512-U/nNG+VLWoPFdwwKx0oliT4ziKQCEoQ27L5Hhw8YOFGA2Po9A9pULUYNWhDgHkrb0gYDNt//X7wABcEWWBd3FQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+            "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
             "dependencies": {
-                "safe-json-utils": "^1.1.1",
-                "tslib": "1.14.1"
+                "@walletconnect/safe-json": "^1.0.1",
+                "idb-keyval": "^6.2.1",
+                "unstorage": "^1.9.0"
             },
             "peerDependencies": {
-                "@react-native-async-storage/async-storage": "1.x",
-                "lokijs": "1.x"
+                "@react-native-async-storage/async-storage": "1.x"
             },
             "peerDependenciesMeta": {
                 "@react-native-async-storage/async-storage": {
                     "optional": true
-                },
-                "lokijs": {
-                    "optional": true
                 }
             }
-        },
-        "node_modules/@walletconnect/keyvaluestorage/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/logger": {
             "version": "2.0.1",
@@ -2332,196 +2295,76 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/modal": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.1.tgz",
-            "integrity": "sha512-G84tSzdPKAFk1zimgV7JzIUFT5olZUVtI3GcOk77OeLYjlMfnDT23RVRHm5EyCrjkptnvpD0wQScXePOFd2Xcw==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.2.tgz",
+            "integrity": "sha512-eFopgKi8AjKf/0U4SemvcYw9zlLpx9njVN8sf6DAkowC2Md0gPU/UNEbH1Wwj407pEKnEds98pKWib1NN1ACoA==",
             "dependencies": {
-                "@walletconnect/modal-core": "2.6.1",
-                "@walletconnect/modal-ui": "2.6.1"
+                "@walletconnect/modal-core": "2.6.2",
+                "@walletconnect/modal-ui": "2.6.2"
             }
         },
         "node_modules/@walletconnect/modal-core": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.1.tgz",
-            "integrity": "sha512-f2hYlJ5pwzGvjyaZ6BoGR5uiMgXzWXt6w6ktt1N8lmY6PiYp8whZgqx2hTxVWwVlsGnaIfh6UHp1hGnANx0eTQ==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.2.tgz",
+            "integrity": "sha512-cv8ibvdOJQv2B+nyxP9IIFdxvQznMz8OOr/oR/AaUZym4hjXNL/l1a2UlSQBXrVjo3xxbouMxLb3kBsHoYP2CA==",
             "dependencies": {
-                "valtio": "1.11.0"
+                "valtio": "1.11.2"
             }
         },
         "node_modules/@walletconnect/modal-ui": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.1.tgz",
-            "integrity": "sha512-RFUOwDAMijSK8B7W3+KoLKaa1l+KEUG0LCrtHqaB0H0cLnhEGdLR+kdTdygw+W8+yYZbkM5tXBm7MlFbcuyitA==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.2.tgz",
+            "integrity": "sha512-rbdstM1HPGvr7jprQkyPggX7rP4XiCG85ZA+zWBEX0dVQg8PpAgRUqpeub4xQKDgY7pY/xLRXSiCVdWGqvG2HA==",
             "dependencies": {
-                "@walletconnect/modal-core": "2.6.1",
-                "lit": "2.7.6",
+                "@walletconnect/modal-core": "2.6.2",
+                "lit": "2.8.0",
                 "motion": "10.16.2",
                 "qrcode": "1.5.3"
             }
         },
-        "node_modules/@walletconnect/modal-ui/node_modules/cliui": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+        "node_modules/@walletconnect/modal-ui/node_modules/@lit/reactive-element": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+            "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
             "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^6.2.0"
+                "@lit-labs/ssr-dom-shim": "^1.0.0"
             }
         },
-        "node_modules/@walletconnect/modal-ui/node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+        "node_modules/@walletconnect/modal-ui/node_modules/lit": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+            "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
             "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
+                "@lit/reactive-element": "^1.6.0",
+                "lit-element": "^3.3.0",
+                "lit-html": "^2.8.0"
             }
         },
-        "node_modules/@walletconnect/modal-ui/node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+        "node_modules/@walletconnect/modal-ui/node_modules/lit-element": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+            "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
             "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
+                "@lit-labs/ssr-dom-shim": "^1.1.0",
+                "@lit/reactive-element": "^1.3.0",
+                "lit-html": "^2.8.0"
             }
         },
-        "node_modules/@walletconnect/modal-ui/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+        "node_modules/@walletconnect/modal-ui/node_modules/lit-html": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
             "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/pngjs": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-            "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/qrcode": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
-            "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
-            "dependencies": {
-                "dijkstrajs": "^1.0.1",
-                "encode-utf8": "^1.0.3",
-                "pngjs": "^5.0.0",
-                "yargs": "^15.3.1"
-            },
-            "bin": {
-                "qrcode": "bin/qrcode"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/y18n": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/yargs": {
-            "version": "15.4.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-            "dependencies": {
-                "cliui": "^6.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^4.1.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^4.2.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@walletconnect/modal-ui/node_modules/yargs-parser": {
-            "version": "18.1.3",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-            "dependencies": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=6"
+                "@types/trusted-types": "^2.0.2"
             }
         },
         "node_modules/@walletconnect/relay-api": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.9.tgz",
-            "integrity": "sha512-Q3+rylJOqRkO1D9Su0DPE3mmznbAalYapJ9qmzDgK28mYF9alcP3UwG/og5V7l7CFOqzCLi7B8BvcBUrpDj0Rg==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+            "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
             "dependencies": {
-                "@walletconnect/jsonrpc-types": "^1.0.2",
-                "tslib": "1.14.1"
+                "@walletconnect/jsonrpc-types": "^1.0.2"
             }
-        },
-        "node_modules/@walletconnect/relay-api/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/relay-auth": {
             "version": "1.0.4",
@@ -2555,18 +2398,18 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/sign-client": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.9.2.tgz",
-            "integrity": "sha512-anRwnXKlR08lYllFMEarS01hp1gr6Q9XUgvacr749hoaC/AwGVlxYFdM8+MyYr3ozlA+2i599kjbK/mAebqdXg==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.11.2.tgz",
+            "integrity": "sha512-MfBcuSz2GmMH+P7MrCP46mVE5qhP0ZyWA0FyIH6/WuxQ6G+MgKsGfaITqakpRPsykWOJq8tXMs3XvUPDU413OQ==",
             "dependencies": {
-                "@walletconnect/core": "2.9.2",
+                "@walletconnect/core": "2.11.2",
                 "@walletconnect/events": "^1.0.1",
                 "@walletconnect/heartbeat": "1.2.1",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/logger": "^2.0.1",
                 "@walletconnect/time": "^1.0.2",
-                "@walletconnect/types": "2.9.2",
-                "@walletconnect/utils": "2.9.2",
+                "@walletconnect/types": "2.11.2",
+                "@walletconnect/utils": "2.11.2",
                 "events": "^3.3.0"
             }
         },
@@ -2584,22 +2427,22 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@walletconnect/types": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.2.tgz",
-            "integrity": "sha512-7Rdn30amnJEEal4hk83cdwHUuxI1SWQ+K7fFFHBMqkuHLGi3tpMY6kpyfDxnUScYEZXqgRps4Jo5qQgnRqVM7A==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.2.tgz",
+            "integrity": "sha512-p632MFB+lJbip2cvtXPBQslpUdiw1sDtQ5y855bOlAGquay+6fZ4h1DcDePeKQDQM3P77ax2a9aNPZxV6y/h1Q==",
             "dependencies": {
                 "@walletconnect/events": "^1.0.1",
                 "@walletconnect/heartbeat": "1.2.1",
                 "@walletconnect/jsonrpc-types": "1.0.3",
-                "@walletconnect/keyvaluestorage": "^1.0.2",
+                "@walletconnect/keyvaluestorage": "^1.1.1",
                 "@walletconnect/logger": "^2.0.1",
                 "events": "^3.3.0"
             }
         },
         "node_modules/@walletconnect/utils": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.2.tgz",
-            "integrity": "sha512-D44hwXET/8JhhIjqljY6qxSu7xXnlPrf63UN/Qfl98vDjWlYVcDl2+JIQRxD9GPastw0S8XZXdRq59XDXLuZBg==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.11.2.tgz",
+            "integrity": "sha512-LyfdmrnZY6dWqlF4eDrx5jpUwsB2bEPjoqR5Z6rXPiHJKUOdJt7az+mNOn5KTSOlRpd1DmozrBrWr+G9fFLYVw==",
             "dependencies": {
                 "@stablelib/chacha20poly1305": "1.0.1",
                 "@stablelib/hkdf": "1.0.1",
@@ -2609,7 +2452,7 @@
                 "@walletconnect/relay-api": "^1.0.9",
                 "@walletconnect/safe-json": "^1.0.2",
                 "@walletconnect/time": "^1.0.2",
-                "@walletconnect/types": "2.9.2",
+                "@walletconnect/types": "2.11.2",
                 "@walletconnect/window-getters": "^1.0.1",
                 "@walletconnect/window-metadata": "^1.0.1",
                 "detect-browser": "5.3.0",
@@ -2798,10 +2641,9 @@
             }
         },
         "node_modules/anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-            "dev": true,
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -2994,10 +2836,9 @@
             "dev": true
         },
         "node_modules/axios": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-            "license": "MIT",
+            "version": "1.7.9",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+            "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -3183,7 +3024,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3220,7 +3060,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -3338,12 +3177,44 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "call-bind-apply-helpers": "^1.0.0",
+                "es-define-property": "^1.0.0",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+            "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3423,16 +3294,9 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -3445,6 +3309,9 @@
             "engines": {
                 "node": ">= 8.10.0"
             },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
             }
@@ -3453,7 +3320,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -3673,6 +3539,14 @@
             "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
             "dev": true
         },
+        "node_modules/consola": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+            "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -3681,6 +3555,11 @@
             "dependencies": {
                 "safe-buffer": "~5.1.1"
             }
+        },
+        "node_modules/cookie-es": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
+            "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
         },
         "node_modules/core-util-is": {
             "version": "1.0.2",
@@ -3700,6 +3579,14 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/crossws": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.1.tgz",
+            "integrity": "sha512-HsZgeVYaG+b5zA+9PbIPGq4+J/CJynJuearykPsXx4V/eMhyQ5EDVg3Ak2FBZtVXCiOLu/U7IiwDHTr9MA+IKw==",
+            "dependencies": {
+                "uncrypto": "^0.1.3"
             }
         },
         "node_modules/css": {
@@ -3960,11 +3847,28 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/define-properties": {
+        "node_modules/define-data-property": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
             },
@@ -3975,6 +3879,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/defu": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+            "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3982,6 +3891,11 @@
             "engines": {
                 "node": ">=0.4.0"
             }
+        },
+        "node_modules/destr": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.3.tgz",
+            "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
         },
         "node_modules/detect-browser": {
             "version": "5.3.0",
@@ -4069,6 +3983,19 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/duplexify": {
@@ -4204,6 +4131,33 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/es-shim-unscopables": {
@@ -5316,6 +5270,14 @@
                 "pend": "~1.2.0"
             }
         },
+        "node_modules/feaxios": {
+            "version": "0.0.23",
+            "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+            "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+            "dependencies": {
+                "is-retry-allowed": "^3.0.0"
+            }
+        },
         "node_modules/figures": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -5356,7 +5318,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -5478,7 +5439,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -5489,9 +5449,12 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.5",
@@ -5542,13 +5505,23 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+            "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.0",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5561,6 +5534,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -5687,11 +5672,39 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
+        },
+        "node_modules/h3": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/h3/-/h3-1.13.1.tgz",
+            "integrity": "sha512-u/z6Z4YY+ANZ05cRRfsFJadTBrNA6e3jxdU+AN5UCbZSZEUwgHiwjvUEe0k1NoQmAvQmETwr+xB5jd7mhCJuIQ==",
+            "dependencies": {
+                "cookie-es": "^1.2.2",
+                "crossws": "^0.3.1",
+                "defu": "^6.1.4",
+                "destr": "^2.0.3",
+                "iron-webcrypto": "^1.2.1",
+                "ohash": "^1.1.4",
+                "radix3": "^1.1.2",
+                "ufo": "^1.5.4",
+                "uncrypto": "^0.1.3",
+                "unenv": "^1.10.0"
+            }
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -5722,20 +5735,20 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dependencies": {
-                "get-intrinsic": "^1.1.1"
+                "es-define-property": "^1.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5765,6 +5778,17 @@
             "dependencies": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/hey-listen": {
@@ -5877,6 +5901,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/idb-keyval": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+            "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
@@ -5996,6 +6025,14 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/iron-webcrypto": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+            "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+            "funding": {
+                "url": "https://github.com/sponsors/brc-dd"
+            }
+        },
         "node_modules/is-arguments": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -6032,7 +6069,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -6108,7 +6144,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6152,7 +6187,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -6191,7 +6225,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -6238,6 +6271,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-retry-allowed": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+            "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-shared-array-buffer": {
@@ -6343,6 +6387,15 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
+        },
+        "node_modules/isomorphic-unfetch": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+            "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+            "dependencies": {
+                "node-fetch": "^2.6.1",
+                "unfetch": "^4.2.0"
+            }
         },
         "node_modules/isstream": {
             "version": "0.1.2",
@@ -7632,34 +7685,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/lit": {
-            "version": "2.7.6",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.6.tgz",
-            "integrity": "sha512-1amFHA7t4VaaDe+vdQejSVBklwtH9svGoG6/dZi9JhxtJBBlqY5D1RV7iLUYY0trCqQc4NfhYYZilZiVHt7Hxg==",
-            "dependencies": {
-                "@lit/reactive-element": "^1.6.0",
-                "lit-element": "^3.3.0",
-                "lit-html": "^2.7.0"
-            }
-        },
-        "node_modules/lit-element": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-            "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-            "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.1.0",
-                "@lit/reactive-element": "^1.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "node_modules/lit-html": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-            "dependencies": {
-                "@types/trusted-types": "^2.0.2"
-            }
-        },
         "node_modules/locate-path": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -7776,13 +7801,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/lokijs": {
-            "version": "1.5.12",
-            "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.12.tgz",
-            "integrity": "sha512-Q5ALD6JiS6xAUWCwX3taQmgwxyveCtIIuL08+ml0nHwT3k0S/GIFJN+Hd38b1qYIMaE5X++iqsqWVksz7SYW+Q==",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7867,6 +7885,14 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7893,6 +7919,17 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/mime": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+            "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/mime-db": {
@@ -8047,6 +8084,49 @@
                 "node": ">=14.18"
             }
         },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch-native": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
+            "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ=="
+        },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/node-gyp-build": {
             "version": "4.8.1",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
@@ -8083,7 +8163,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8123,13 +8202,15 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "has-symbols": "^1.0.1",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0",
+                "has-symbols": "^1.1.0",
                 "object-keys": "^1.1.1"
             },
             "engines": {
@@ -8169,6 +8250,21 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/ofetch": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
+            "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
+            "dependencies": {
+                "destr": "^2.0.3",
+                "node-fetch-native": "^1.6.4",
+                "ufo": "^1.5.4"
+            }
+        },
+        "node_modules/ohash": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
+            "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g=="
         },
         "node_modules/on-exit-leak-free": {
             "version": "0.2.0",
@@ -8357,6 +8453,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+        },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -8379,7 +8480,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -8532,6 +8632,14 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/pngjs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+            "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/postcss": {
@@ -8713,6 +8821,148 @@
                 "node": ">=6"
             }
         },
+        "node_modules/qrcode": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+            "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+            "dependencies": {
+                "dijkstrajs": "^1.0.1",
+                "encode-utf8": "^1.0.3",
+                "pngjs": "^5.0.0",
+                "yargs": "^15.3.1"
+            },
+            "bin": {
+                "qrcode": "bin/qrcode"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/qrcode/node_modules/cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/qrcode/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/qrcode/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/qrcode/node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/y18n": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+        },
+        "node_modules/qrcode/node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/qrcode/node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/qs": {
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -8764,6 +9014,11 @@
             "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
             "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
         },
+        "node_modules/radix3": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+            "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8773,9 +9028,9 @@
             }
         },
         "node_modules/react": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -8807,7 +9062,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -9082,9 +9336,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-            "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -9105,11 +9359,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "node_modules/safe-json-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-            "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
         },
         "node_modules/safe-stable-stringify": {
             "version": "2.4.3",
@@ -9168,9 +9417,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -9180,6 +9429,22 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/sha.js": {
             "version": "2.4.11",
@@ -9293,10 +9558,9 @@
             }
         },
         "node_modules/sodium-native": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.1.1.tgz",
-            "integrity": "sha512-LXkAfRd4FHtkQS4X6g+nRcVaN7mWVNepV06phIsC6+IZFvGh1voW5TNQiQp2twVaMf05gZqQjuS+uWLM6gHhNQ==",
-            "hasInstallScript": true,
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+            "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
             "optional": true,
             "dependencies": {
                 "node-gyp-build": "^4.8.0"
@@ -9524,6 +9788,22 @@
                 "randombytes": "^2.1.0",
                 "toml": "^3.0.0",
                 "urijs": "^1.19.1"
+            }
+        },
+        "node_modules/stellar-sdk/node_modules/@stellar/stellar-base": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-10.0.1.tgz",
+            "integrity": "sha512-BDbx7VHOEQh+4J3Q+gStNXgPaNckVFmD4aOlBBGwxlF6vPFmVnW8IoJdkX7T58zpX55eWI6DXvEhDBlrqTlhAQ==",
+            "dependencies": {
+                "@stellar/js-xdr": "^3.0.1",
+                "base32.js": "^0.1.0",
+                "bignumber.js": "^9.1.2",
+                "buffer": "^6.0.3",
+                "sha.js": "^2.3.6",
+                "tweetnacl": "^1.0.3"
+            },
+            "optionalDependencies": {
+                "sodium-native": "^4.0.1"
             }
         },
         "node_modules/stream-shift": {
@@ -9994,7 +10274,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -10124,9 +10403,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -10226,6 +10505,11 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/ufo": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+            "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
+        },
         "node_modules/uint8arrays": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -10248,6 +10532,28 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/uncrypto": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+        },
+        "node_modules/unenv": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
+            "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
+            "dependencies": {
+                "consola": "^3.2.3",
+                "defu": "^6.1.4",
+                "mime": "^3.0.0",
+                "node-fetch-native": "^1.6.4",
+                "pathe": "^1.1.2"
+            }
+        },
+        "node_modules/unfetch": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+            "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+        },
         "node_modules/universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -10256,6 +10562,102 @@
             "engines": {
                 "node": ">= 10.0.0"
             }
+        },
+        "node_modules/unstorage": {
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.14.4.tgz",
+            "integrity": "sha512-1SYeamwuYeQJtJ/USE1x4l17LkmQBzg7deBJ+U9qOBoHo15d1cDxG4jM31zKRgF7pG0kirZy4wVMX6WL6Zoscg==",
+            "dependencies": {
+                "anymatch": "^3.1.3",
+                "chokidar": "^3.6.0",
+                "destr": "^2.0.3",
+                "h3": "^1.13.0",
+                "lru-cache": "^10.4.3",
+                "node-fetch-native": "^1.6.4",
+                "ofetch": "^1.4.1",
+                "ufo": "^1.5.4"
+            },
+            "peerDependencies": {
+                "@azure/app-configuration": "^1.8.0",
+                "@azure/cosmos": "^4.2.0",
+                "@azure/data-tables": "^13.3.0",
+                "@azure/identity": "^4.5.0",
+                "@azure/keyvault-secrets": "^4.9.0",
+                "@azure/storage-blob": "^12.26.0",
+                "@capacitor/preferences": "^6.0.3",
+                "@deno/kv": ">=0.8.4",
+                "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0",
+                "@planetscale/database": "^1.19.0",
+                "@upstash/redis": "^1.34.3",
+                "@vercel/blob": ">=0.27.0",
+                "@vercel/kv": "^1.0.1",
+                "aws4fetch": "^1.0.20",
+                "db0": ">=0.2.1",
+                "idb-keyval": "^6.2.1",
+                "ioredis": "^5.4.2",
+                "uploadthing": "^7.4.1"
+            },
+            "peerDependenciesMeta": {
+                "@azure/app-configuration": {
+                    "optional": true
+                },
+                "@azure/cosmos": {
+                    "optional": true
+                },
+                "@azure/data-tables": {
+                    "optional": true
+                },
+                "@azure/identity": {
+                    "optional": true
+                },
+                "@azure/keyvault-secrets": {
+                    "optional": true
+                },
+                "@azure/storage-blob": {
+                    "optional": true
+                },
+                "@capacitor/preferences": {
+                    "optional": true
+                },
+                "@deno/kv": {
+                    "optional": true
+                },
+                "@netlify/blobs": {
+                    "optional": true
+                },
+                "@planetscale/database": {
+                    "optional": true
+                },
+                "@upstash/redis": {
+                    "optional": true
+                },
+                "@vercel/blob": {
+                    "optional": true
+                },
+                "@vercel/kv": {
+                    "optional": true
+                },
+                "aws4fetch": {
+                    "optional": true
+                },
+                "db0": {
+                    "optional": true
+                },
+                "idb-keyval": {
+                    "optional": true
+                },
+                "ioredis": {
+                    "optional": true
+                },
+                "uploadthing": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unstorage/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
         },
         "node_modules/untildify": {
             "version": "4.0.0",
@@ -10289,15 +10691,14 @@
             }
         },
         "node_modules/util": {
-            "version": "0.12.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-            "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "is-arguments": "^1.0.4",
                 "is-generator-function": "^1.0.7",
                 "is-typed-array": "^1.1.3",
-                "safe-buffer": "^5.1.2",
                 "which-typed-array": "^1.1.2"
             }
         },
@@ -10345,9 +10746,9 @@
             }
         },
         "node_modules/valtio": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.0.tgz",
-            "integrity": "sha512-65Yd0yU5qs86b5lN1eu/nzcTgQ9/6YnD6iO+DDaDbQLn1Zv2w12Gwk43WkPlUBxk5wL/6cD5YMFf7kj6HZ1Kpg==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.2.tgz",
+            "integrity": "sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw==",
             "dependencies": {
                 "proxy-compare": "2.5.1",
                 "use-sync-external-store": "1.2.0"
@@ -10356,9 +10757,13 @@
                 "node": ">=12.20.0"
             },
             "peerDependencies": {
+                "@types/react": ">=16.8",
                 "react": ">=16.8"
             },
             "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
                 "react": {
                     "optional": true
                 }
@@ -10681,12 +11086,13 @@
     },
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.24.2",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
             }
         },
@@ -10769,44 +11175,103 @@
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-            "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.26.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+                    "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.26.5",
+                        "@babel/types": "^7.26.5",
+                        "@jridgewell/gen-mapping": "^0.3.5",
+                        "@jridgewell/trace-mapping": "^0.3.25",
+                        "jsesc": "^3.0.2"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.26.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+                    "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.26.2",
+                        "@babel/generator": "^7.26.5",
+                        "@babel/parser": "^7.26.5",
+                        "@babel/template": "^7.25.9",
+                        "@babel/types": "^7.26.5",
+                        "debug": "^4.3.1",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "jsesc": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+                    "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz",
-            "integrity": "sha512-t5s2BeSWIghhFRPh9XMn6EIGmvn8Lmw5RVASJzkIx1mSemubQQBNIZiQD7WzaFmaHIrjAec4x8z9Yx8SjJ1/LA==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
             "dev": true,
             "requires": {
-                "@babel/helper-environment-visitor": "^7.16.7",
-                "@babel/helper-module-imports": "^7.16.7",
-                "@babel/helper-simple-access": "^7.17.7",
-                "@babel/helper-split-export-declaration": "^7.16.7",
-                "@babel/helper-validator-identifier": "^7.16.7",
-                "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.17.12",
-                "@babel/types": "^7.17.12"
+                "@babel/helper-module-imports": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
+            },
+            "dependencies": {
+                "@babel/generator": {
+                    "version": "7.26.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+                    "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.26.5",
+                        "@babel/types": "^7.26.5",
+                        "@jridgewell/gen-mapping": "^0.3.5",
+                        "@jridgewell/trace-mapping": "^0.3.25",
+                        "jsesc": "^3.0.2"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.26.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+                    "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.26.2",
+                        "@babel/generator": "^7.26.5",
+                        "@babel/parser": "^7.26.5",
+                        "@babel/template": "^7.25.9",
+                        "@babel/types": "^7.26.5",
+                        "debug": "^4.3.1",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "jsesc": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+                    "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
-            "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
             "dev": true
-        },
-        "@babel/helper-simple-access": {
-            "version": "7.17.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
-            "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.17.0"
-            }
         },
         "@babel/helper-split-export-declaration": {
             "version": "7.24.5",
@@ -10818,21 +11283,21 @@
             }
         },
         "@babel/helper-string-parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
             "dev": true
         },
         "@babel/helper-validator-option": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-            "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
             "dev": true
         },
         "@babel/helpers": {
@@ -10846,81 +11311,14 @@
                 "@babel/types": "^7.17.0"
             }
         },
-        "@babel/highlight": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-            "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+        "@babel/parser": {
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+            "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.24.5",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-                    "dev": true
-                },
-                "escape-string-regexp": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                    "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
+                "@babel/types": "^7.26.5"
             }
-        },
-        "@babel/parser": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
-            "dev": true
         },
         "@babel/plugin-syntax-async-generators": {
             "version": "7.8.4",
@@ -11031,12 +11429,12 @@
             }
         },
         "@babel/plugin-syntax-typescript": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.17.12.tgz",
-            "integrity": "sha512-TYY0SXFiO31YXtNg3HtFwNJHjLsAyIIhAhNWkQ5whPPS7HWUFlg9z0Ta4qAQNjQbP1wsSt/oKkmZ/4/WWdMUpw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+            "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.17.12"
+                "@babel/helper-plugin-utils": "^7.25.9"
             }
         },
         "@babel/runtime": {
@@ -11049,14 +11447,14 @@
             }
         },
         "@babel/template": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/parser": "^7.24.0",
-                "@babel/types": "^7.24.0"
+                "@babel/code-frame": "^7.25.9",
+                "@babel/parser": "^7.25.9",
+                "@babel/types": "^7.25.9"
             }
         },
         "@babel/traverse": {
@@ -11092,14 +11490,13 @@
             }
         },
         "@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+            "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             }
         },
         "@bcoe/v8-coverage": {
@@ -11115,9 +11512,10 @@
             "dev": true,
             "optional": true
         },
-        "@creit-tech/xbull-wallet-connect": {
-            "version": "git+ssh://git@github.com/Creit-Tech/xBull-Wallet-Connect.git#bf6725307a5de7e513aa67fa6b8bdbf58797af1d",
-            "from": "@creit-tech/xbull-wallet-connect@github:Creit-Tech/xBull-Wallet-Connect",
+        "@creit.tech/xbull-wallet-connect": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.3.0.tgz",
+            "integrity": "sha512-pByi0bTAWd2ZdolVtkXcAU1DYTtz/cJc/IkRUz9x9/1NsFVyrM4UxE8tHgVZ3mwrJ4josoDwYP957ynQw195YQ==",
             "requires": {
                 "rxjs": "^7.5.5",
                 "tweetnacl": "^1.0.3",
@@ -11589,17 +11987,9 @@
             }
         },
         "@lit-labs/ssr-dom-shim": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
-            "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
-        },
-        "@lit/reactive-element": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-            "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-            "requires": {
-                "@lit-labs/ssr-dom-shim": "^1.0.0"
-            }
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+            "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ=="
         },
         "@lobstrco/signer-extension-api": {
             "version": "1.0.0-beta.0",
@@ -11607,78 +11997,78 @@
             "integrity": "sha512-16V34W9MyTgunGvgkzv1JmV+k59OjNWCrNOH+KH+6vWamcGDGBnFhvRgGEarEhINYITMGkdqEvaEy7qTD5s5cw=="
         },
         "@motionone/animation": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
-            "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
+            "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
             "requires": {
-                "@motionone/easing": "^10.15.1",
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
+                "@motionone/easing": "^10.18.0",
+                "@motionone/types": "^10.17.1",
+                "@motionone/utils": "^10.18.0",
                 "tslib": "^2.3.1"
             }
         },
         "@motionone/dom": {
-            "version": "10.16.2",
-            "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
-            "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.18.0.tgz",
+            "integrity": "sha512-bKLP7E0eyO4B2UaHBBN55tnppwRnaE3KFfh3Ps9HhnAkar3Cb69kUCJY9as8LrccVYKgHA+JY5dOQqJLOPhF5A==",
             "requires": {
-                "@motionone/animation": "^10.15.1",
-                "@motionone/generators": "^10.15.1",
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
+                "@motionone/animation": "^10.18.0",
+                "@motionone/generators": "^10.18.0",
+                "@motionone/types": "^10.17.1",
+                "@motionone/utils": "^10.18.0",
                 "hey-listen": "^1.0.8",
                 "tslib": "^2.3.1"
             }
         },
         "@motionone/easing": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
-            "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
+            "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
             "requires": {
-                "@motionone/utils": "^10.15.1",
+                "@motionone/utils": "^10.18.0",
                 "tslib": "^2.3.1"
             }
         },
         "@motionone/generators": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
-            "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
+            "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
             "requires": {
-                "@motionone/types": "^10.15.1",
-                "@motionone/utils": "^10.15.1",
+                "@motionone/types": "^10.17.1",
+                "@motionone/utils": "^10.18.0",
                 "tslib": "^2.3.1"
             }
         },
         "@motionone/svelte": {
-            "version": "10.16.2",
-            "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.2.tgz",
-            "integrity": "sha512-38xsroKrfK+aHYhuQlE6eFcGy0EwrB43Q7RGjF73j/kRUTcLNu/LAaKiLLsN5lyqVzCgTBVt4TMT/ShWbTbc5Q==",
+            "version": "10.16.4",
+            "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.4.tgz",
+            "integrity": "sha512-zRVqk20lD1xqe+yEDZhMYgftsuHc25+9JSo+r0a0OWUJFocjSV9D/+UGhX4xgJsuwB9acPzXLr20w40VnY2PQA==",
             "requires": {
-                "@motionone/dom": "^10.16.2",
+                "@motionone/dom": "^10.16.4",
                 "tslib": "^2.3.1"
             }
         },
         "@motionone/types": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
-            "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
+            "version": "10.17.1",
+            "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
+            "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A=="
         },
         "@motionone/utils": {
-            "version": "10.15.1",
-            "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
-            "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
+            "version": "10.18.0",
+            "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
+            "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
             "requires": {
-                "@motionone/types": "^10.15.1",
+                "@motionone/types": "^10.17.1",
                 "hey-listen": "^1.0.8",
                 "tslib": "^2.3.1"
             }
         },
         "@motionone/vue": {
-            "version": "10.16.2",
-            "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.2.tgz",
-            "integrity": "sha512-7/dEK/nWQXOkJ70bqb2KyNfSWbNvWqKKq1C8juj+0Mg/AorgD8O5wE3naddK0G+aXuNMqRuc4jlsYHHWHtIzVw==",
+            "version": "10.16.4",
+            "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.4.tgz",
+            "integrity": "sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==",
             "requires": {
-                "@motionone/dom": "^10.16.2",
+                "@motionone/dom": "^10.16.4",
                 "tslib": "^2.3.1"
             }
         },
@@ -11892,45 +12282,32 @@
             "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
             "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
         },
-        "@stellar/stellar-base": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-10.0.1.tgz",
-            "integrity": "sha512-BDbx7VHOEQh+4J3Q+gStNXgPaNckVFmD4aOlBBGwxlF6vPFmVnW8IoJdkX7T58zpX55eWI6DXvEhDBlrqTlhAQ==",
-            "requires": {
-                "@stellar/js-xdr": "^3.0.1",
-                "base32.js": "^0.1.0",
-                "bignumber.js": "^9.1.2",
-                "buffer": "^6.0.3",
-                "sha.js": "^2.3.6",
-                "sodium-native": "^4.0.1",
-                "tweetnacl": "^1.0.3"
-            }
-        },
         "@stellar/stellar-sdk": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
-            "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.1.0.tgz",
+            "integrity": "sha512-ARQkUdyGefXdTgwSF0eONkzv/geAqUfyfheJ9Nthz6GAr5b41fNwWW9UtE8JpXC4IpvE3t5elIUN5hKJzASN9w==",
             "requires": {
-                "@stellar/stellar-base": "^12.1.1",
-                "axios": "^1.7.7",
+                "@stellar/stellar-base": "^13.0.1",
+                "axios": "^1.7.9",
                 "bignumber.js": "^9.1.2",
                 "eventsource": "^2.0.2",
+                "feaxios": "^0.0.23",
                 "randombytes": "^2.1.0",
                 "toml": "^3.0.0",
                 "urijs": "^1.19.1"
             },
             "dependencies": {
                 "@stellar/stellar-base": {
-                    "version": "12.1.1",
-                    "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-                    "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
+                    "version": "13.0.1",
+                    "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.0.1.tgz",
+                    "integrity": "sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==",
                     "requires": {
                         "@stellar/js-xdr": "^3.1.2",
                         "base32.js": "^0.1.0",
                         "bignumber.js": "^9.1.2",
                         "buffer": "^6.0.3",
                         "sha.js": "^2.3.6",
-                        "sodium-native": "^4.1.1",
+                        "sodium-native": "^4.3.0",
                         "tweetnacl": "^1.0.3"
                     }
                 }
@@ -12224,9 +12601,9 @@
             }
         },
         "@types/trusted-types": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-            "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "@types/yargs": {
             "version": "16.0.4",
@@ -12371,24 +12748,25 @@
             }
         },
         "@walletconnect/core": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.2.tgz",
-            "integrity": "sha512-VARMPAx8sIgodeyngDHbealP3B621PQqjqKsByFUTOep8ZI1/R/20zU+cmq6j9RCrL+kLKZcrZqeVzs8Z7OlqQ==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.11.2.tgz",
+            "integrity": "sha512-bB4SiXX8hX3/hyBfVPC5gwZCXCl+OPj+/EDVM71iAO3TDsh78KPbrVAbDnnsbHzZVHlsMohtXX3j5XVsheN3+g==",
             "requires": {
                 "@walletconnect/heartbeat": "1.2.1",
                 "@walletconnect/jsonrpc-provider": "1.0.13",
                 "@walletconnect/jsonrpc-types": "1.0.3",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
-                "@walletconnect/jsonrpc-ws-connection": "1.0.13",
-                "@walletconnect/keyvaluestorage": "^1.0.2",
+                "@walletconnect/jsonrpc-ws-connection": "1.0.14",
+                "@walletconnect/keyvaluestorage": "^1.1.1",
                 "@walletconnect/logger": "^2.0.1",
                 "@walletconnect/relay-api": "^1.0.9",
                 "@walletconnect/relay-auth": "^1.0.4",
                 "@walletconnect/safe-json": "^1.0.2",
                 "@walletconnect/time": "^1.0.2",
-                "@walletconnect/types": "2.9.2",
-                "@walletconnect/utils": "2.9.2",
+                "@walletconnect/types": "2.11.2",
+                "@walletconnect/utils": "2.11.2",
                 "events": "^3.3.0",
+                "isomorphic-unfetch": "3.1.0",
                 "lodash.isequal": "4.5.0",
                 "uint8arrays": "^3.1.0"
             }
@@ -12492,38 +12870,24 @@
             }
         },
         "@walletconnect/jsonrpc-ws-connection": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
-            "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
+            "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
             "requires": {
                 "@walletconnect/jsonrpc-utils": "^1.0.6",
                 "@walletconnect/safe-json": "^1.0.2",
                 "events": "^3.3.0",
-                "tslib": "1.14.1",
                 "ws": "^7.5.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
             }
         },
         "@walletconnect/keyvaluestorage": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.2.tgz",
-            "integrity": "sha512-U/nNG+VLWoPFdwwKx0oliT4ziKQCEoQ27L5Hhw8YOFGA2Po9A9pULUYNWhDgHkrb0gYDNt//X7wABcEWWBd3FQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+            "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
             "requires": {
-                "safe-json-utils": "^1.1.1",
-                "tslib": "1.14.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@walletconnect/safe-json": "^1.0.1",
+                "idb-keyval": "^6.2.1",
+                "unstorage": "^1.9.0"
             }
         },
         "@walletconnect/logger": {
@@ -12543,160 +12907,77 @@
             }
         },
         "@walletconnect/modal": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.1.tgz",
-            "integrity": "sha512-G84tSzdPKAFk1zimgV7JzIUFT5olZUVtI3GcOk77OeLYjlMfnDT23RVRHm5EyCrjkptnvpD0wQScXePOFd2Xcw==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.2.tgz",
+            "integrity": "sha512-eFopgKi8AjKf/0U4SemvcYw9zlLpx9njVN8sf6DAkowC2Md0gPU/UNEbH1Wwj407pEKnEds98pKWib1NN1ACoA==",
             "requires": {
-                "@walletconnect/modal-core": "2.6.1",
-                "@walletconnect/modal-ui": "2.6.1"
+                "@walletconnect/modal-core": "2.6.2",
+                "@walletconnect/modal-ui": "2.6.2"
             }
         },
         "@walletconnect/modal-core": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.1.tgz",
-            "integrity": "sha512-f2hYlJ5pwzGvjyaZ6BoGR5uiMgXzWXt6w6ktt1N8lmY6PiYp8whZgqx2hTxVWwVlsGnaIfh6UHp1hGnANx0eTQ==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.2.tgz",
+            "integrity": "sha512-cv8ibvdOJQv2B+nyxP9IIFdxvQznMz8OOr/oR/AaUZym4hjXNL/l1a2UlSQBXrVjo3xxbouMxLb3kBsHoYP2CA==",
             "requires": {
-                "valtio": "1.11.0"
+                "valtio": "1.11.2"
             }
         },
         "@walletconnect/modal-ui": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.1.tgz",
-            "integrity": "sha512-RFUOwDAMijSK8B7W3+KoLKaa1l+KEUG0LCrtHqaB0H0cLnhEGdLR+kdTdygw+W8+yYZbkM5tXBm7MlFbcuyitA==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.2.tgz",
+            "integrity": "sha512-rbdstM1HPGvr7jprQkyPggX7rP4XiCG85ZA+zWBEX0dVQg8PpAgRUqpeub4xQKDgY7pY/xLRXSiCVdWGqvG2HA==",
             "requires": {
-                "@walletconnect/modal-core": "2.6.1",
-                "lit": "2.7.6",
+                "@walletconnect/modal-core": "2.6.2",
+                "lit": "2.8.0",
                 "motion": "10.16.2",
                 "qrcode": "1.5.3"
             },
             "dependencies": {
-                "cliui": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                "@lit/reactive-element": {
+                    "version": "1.6.3",
+                    "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+                    "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
                     "requires": {
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.0",
-                        "wrap-ansi": "^6.2.0"
+                        "@lit-labs/ssr-dom-shim": "^1.0.0"
                     }
                 },
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                "lit": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+                    "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
                     "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
+                        "@lit/reactive-element": "^1.6.0",
+                        "lit-element": "^3.3.0",
+                        "lit-html": "^2.8.0"
                     }
                 },
-                "locate-path": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                "lit-element": {
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+                    "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
                     "requires": {
-                        "p-locate": "^4.1.0"
+                        "@lit-labs/ssr-dom-shim": "^1.1.0",
+                        "@lit/reactive-element": "^1.3.0",
+                        "lit-html": "^2.8.0"
                     }
                 },
-                "p-limit": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                "lit-html": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+                    "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
                     "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                    "requires": {
-                        "p-limit": "^2.2.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-                },
-                "pngjs": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-                    "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
-                },
-                "qrcode": {
-                    "version": "1.5.3",
-                    "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
-                    "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
-                    "requires": {
-                        "dijkstrajs": "^1.0.1",
-                        "encode-utf8": "^1.0.3",
-                        "pngjs": "^5.0.0",
-                        "yargs": "^15.3.1"
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-                    "requires": {
-                        "ansi-styles": "^4.0.0",
-                        "string-width": "^4.1.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                },
-                "y18n": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-                    "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-                },
-                "yargs": {
-                    "version": "15.4.1",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-                    "requires": {
-                        "cliui": "^6.0.0",
-                        "decamelize": "^1.2.0",
-                        "find-up": "^4.1.0",
-                        "get-caller-file": "^2.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^2.0.0",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^4.2.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^4.0.0",
-                        "yargs-parser": "^18.1.2"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "18.1.3",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
+                        "@types/trusted-types": "^2.0.2"
                     }
                 }
             }
         },
         "@walletconnect/relay-api": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.9.tgz",
-            "integrity": "sha512-Q3+rylJOqRkO1D9Su0DPE3mmznbAalYapJ9qmzDgK28mYF9alcP3UwG/og5V7l7CFOqzCLi7B8BvcBUrpDj0Rg==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+            "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
             "requires": {
-                "@walletconnect/jsonrpc-types": "^1.0.2",
-                "tslib": "1.14.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@walletconnect/jsonrpc-types": "^1.0.2"
             }
         },
         "@walletconnect/relay-auth": {
@@ -12735,18 +13016,18 @@
             }
         },
         "@walletconnect/sign-client": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.9.2.tgz",
-            "integrity": "sha512-anRwnXKlR08lYllFMEarS01hp1gr6Q9XUgvacr749hoaC/AwGVlxYFdM8+MyYr3ozlA+2i599kjbK/mAebqdXg==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.11.2.tgz",
+            "integrity": "sha512-MfBcuSz2GmMH+P7MrCP46mVE5qhP0ZyWA0FyIH6/WuxQ6G+MgKsGfaITqakpRPsykWOJq8tXMs3XvUPDU413OQ==",
             "requires": {
-                "@walletconnect/core": "2.9.2",
+                "@walletconnect/core": "2.11.2",
                 "@walletconnect/events": "^1.0.1",
                 "@walletconnect/heartbeat": "1.2.1",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/logger": "^2.0.1",
                 "@walletconnect/time": "^1.0.2",
-                "@walletconnect/types": "2.9.2",
-                "@walletconnect/utils": "2.9.2",
+                "@walletconnect/types": "2.11.2",
+                "@walletconnect/utils": "2.11.2",
                 "events": "^3.3.0"
             }
         },
@@ -12766,22 +13047,22 @@
             }
         },
         "@walletconnect/types": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.2.tgz",
-            "integrity": "sha512-7Rdn30amnJEEal4hk83cdwHUuxI1SWQ+K7fFFHBMqkuHLGi3tpMY6kpyfDxnUScYEZXqgRps4Jo5qQgnRqVM7A==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.2.tgz",
+            "integrity": "sha512-p632MFB+lJbip2cvtXPBQslpUdiw1sDtQ5y855bOlAGquay+6fZ4h1DcDePeKQDQM3P77ax2a9aNPZxV6y/h1Q==",
             "requires": {
                 "@walletconnect/events": "^1.0.1",
                 "@walletconnect/heartbeat": "1.2.1",
                 "@walletconnect/jsonrpc-types": "1.0.3",
-                "@walletconnect/keyvaluestorage": "^1.0.2",
+                "@walletconnect/keyvaluestorage": "^1.1.1",
                 "@walletconnect/logger": "^2.0.1",
                 "events": "^3.3.0"
             }
         },
         "@walletconnect/utils": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.2.tgz",
-            "integrity": "sha512-D44hwXET/8JhhIjqljY6qxSu7xXnlPrf63UN/Qfl98vDjWlYVcDl2+JIQRxD9GPastw0S8XZXdRq59XDXLuZBg==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.11.2.tgz",
+            "integrity": "sha512-LyfdmrnZY6dWqlF4eDrx5jpUwsB2bEPjoqR5Z6rXPiHJKUOdJt7az+mNOn5KTSOlRpd1DmozrBrWr+G9fFLYVw==",
             "requires": {
                 "@stablelib/chacha20poly1305": "1.0.1",
                 "@stablelib/hkdf": "1.0.1",
@@ -12791,7 +13072,7 @@
                 "@walletconnect/relay-api": "^1.0.9",
                 "@walletconnect/safe-json": "^1.0.2",
                 "@walletconnect/time": "^1.0.2",
-                "@walletconnect/types": "2.9.2",
+                "@walletconnect/types": "2.11.2",
                 "@walletconnect/window-getters": "^1.0.1",
                 "@walletconnect/window-metadata": "^1.0.1",
                 "detect-browser": "5.3.0",
@@ -12938,10 +13219,9 @@
             }
         },
         "anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-            "dev": true,
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -13072,9 +13352,9 @@
             "dev": true
         },
         "axios": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+            "version": "1.7.9",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+            "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
             "requires": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -13216,8 +13496,7 @@
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
         },
         "blob-util": {
             "version": "2.0.2",
@@ -13251,7 +13530,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -13327,12 +13605,32 @@
             "dev": true
         },
         "call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "call-bind-apply-helpers": "^1.0.0",
+                "es-define-property": "^1.0.0",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.2"
+            }
+        },
+        "call-bind-apply-helpers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+            "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
+        "call-bound": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "get-intrinsic": "^1.2.6"
             }
         },
         "callsites": {
@@ -13381,10 +13679,9 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "dev": true,
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "requires": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -13400,7 +13697,6 @@
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-                    "dev": true,
                     "requires": {
                         "is-glob": "^4.0.1"
                     }
@@ -13567,6 +13863,11 @@
             "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
             "dev": true
         },
+        "consola": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+            "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA=="
+        },
         "convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -13575,6 +13876,11 @@
             "requires": {
                 "safe-buffer": "~5.1.1"
             }
+        },
+        "cookie-es": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
+            "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -13591,6 +13897,14 @@
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
+            }
+        },
+        "crossws": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.1.tgz",
+            "integrity": "sha512-HsZgeVYaG+b5zA+9PbIPGq4+J/CJynJuearykPsXx4V/eMhyQ5EDVg3Ak2FBZtVXCiOLu/U7IiwDHTr9MA+IKw==",
+            "requires": {
+                "uncrypto": "^0.1.3"
             }
         },
         "css": {
@@ -13795,19 +14109,40 @@
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
         },
-        "define-properties": {
+        "define-data-property": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "requires": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            }
+        },
+        "define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "requires": {
+                "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
             }
+        },
+        "defu": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+            "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
         },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "destr": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.3.tgz",
+            "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
         },
         "detect-browser": {
             "version": "5.3.0",
@@ -13876,6 +14211,16 @@
                     "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
                     "dev": true
                 }
+            }
+        },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
             }
         },
         "duplexify": {
@@ -13996,6 +14341,24 @@
                 "string.prototype.trimend": "^1.0.5",
                 "string.prototype.trimstart": "^1.0.5",
                 "unbox-primitive": "^1.0.2"
+            }
+        },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+        },
+        "es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "requires": {
+                "es-errors": "^1.3.0"
             }
         },
         "es-shim-unscopables": {
@@ -14738,6 +15101,14 @@
                 "pend": "~1.2.0"
             }
         },
+        "feaxios": {
+            "version": "0.0.23",
+            "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+            "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+            "requires": {
+                "is-retry-allowed": "^3.0.0"
+            }
+        },
         "figures": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -14768,7 +15139,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -14855,13 +15225,12 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "optional": true
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
         },
         "function.prototype.name": {
             "version": "1.1.5",
@@ -14897,13 +15266,20 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+            "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.0",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
             }
         },
         "get-package-type": {
@@ -14911,6 +15287,15 @@
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            }
         },
         "get-stream": {
             "version": "5.2.0",
@@ -15000,11 +15385,33 @@
                 "slash": "^3.0.0"
             }
         },
+        "gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+        },
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
+        },
+        "h3": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/h3/-/h3-1.13.1.tgz",
+            "integrity": "sha512-u/z6Z4YY+ANZ05cRRfsFJadTBrNA6e3jxdU+AN5UCbZSZEUwgHiwjvUEe0k1NoQmAvQmETwr+xB5jd7mhCJuIQ==",
+            "requires": {
+                "cookie-es": "^1.2.2",
+                "crossws": "^0.3.1",
+                "defu": "^6.1.4",
+                "destr": "^2.0.3",
+                "iron-webcrypto": "^1.2.1",
+                "ohash": "^1.1.4",
+                "radix3": "^1.1.2",
+                "ufo": "^1.5.4",
+                "uncrypto": "^0.1.3",
+                "unenv": "^1.10.0"
+            }
         },
         "has": {
             "version": "1.0.3",
@@ -15026,17 +15433,17 @@
             "dev": true
         },
         "has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "requires": {
-                "get-intrinsic": "^1.1.1"
+                "es-define-property": "^1.0.0"
             }
         },
         "has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
         },
         "has-tostringtag": {
             "version": "1.0.0",
@@ -15054,6 +15461,14 @@
             "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "requires": {
+                "function-bind": "^1.1.2"
             }
         },
         "hey-listen": {
@@ -15140,6 +15555,11 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
+        "idb-keyval": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+            "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
+        },
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -15214,6 +15634,11 @@
                 "side-channel": "^1.0.4"
             }
         },
+        "iron-webcrypto": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+            "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="
+        },
         "is-arguments": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -15241,7 +15666,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
@@ -15289,8 +15713,7 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
             "version": "4.0.0",
@@ -15316,7 +15739,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -15339,8 +15761,7 @@
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "is-number-object": {
             "version": "1.0.7",
@@ -15370,6 +15791,11 @@
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
             }
+        },
+        "is-retry-allowed": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+            "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A=="
         },
         "is-shared-array-buffer": {
             "version": "1.0.2",
@@ -15438,6 +15864,15 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
+        },
+        "isomorphic-unfetch": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+            "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+            "requires": {
+                "node-fetch": "^2.6.1",
+                "unfetch": "^4.2.0"
+            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -16418,34 +16853,6 @@
                 }
             }
         },
-        "lit": {
-            "version": "2.7.6",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.6.tgz",
-            "integrity": "sha512-1amFHA7t4VaaDe+vdQejSVBklwtH9svGoG6/dZi9JhxtJBBlqY5D1RV7iLUYY0trCqQc4NfhYYZilZiVHt7Hxg==",
-            "requires": {
-                "@lit/reactive-element": "^1.6.0",
-                "lit-element": "^3.3.0",
-                "lit-html": "^2.7.0"
-            }
-        },
-        "lit-element": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-            "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-            "requires": {
-                "@lit-labs/ssr-dom-shim": "^1.1.0",
-                "@lit/reactive-element": "^1.3.0",
-                "lit-html": "^2.8.0"
-            }
-        },
-        "lit-html": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-            "requires": {
-                "@types/trusted-types": "^2.0.2"
-            }
-        },
         "locate-path": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -16537,13 +16944,6 @@
                 }
             }
         },
-        "lokijs": {
-            "version": "1.5.12",
-            "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.12.tgz",
-            "integrity": "sha512-Q5ALD6JiS6xAUWCwX3taQmgwxyveCtIIuL08+ml0nHwT3k0S/GIFJN+Hd38b1qYIMaE5X++iqsqWVksz7SYW+Q==",
-            "optional": true,
-            "peer": true
-        },
         "loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -16610,6 +17010,11 @@
                 "tmpl": "1.0.5"
             }
         },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -16631,6 +17036,11 @@
                 "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
             }
+        },
+        "mime": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+            "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
         },
         "mime-db": {
             "version": "1.52.0",
@@ -16748,6 +17158,40 @@
             "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.9.tgz",
             "integrity": "sha512-FSvAol2Z8UP191sZtsUZwHIN0eGoGue3uEXGdWIH5228e9KH1YHXT7fN8Oa33UGf+FbqGTQg3sJfrRGzmVCaJA=="
         },
+        "node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "node-fetch-native": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
+            "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ=="
+        },
         "node-gyp-build": {
             "version": "4.8.1",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
@@ -16778,8 +17222,7 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "npm-run-path": {
             "version": "4.0.1",
@@ -16807,13 +17250,15 @@
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object.assign": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
             "requires": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "has-symbols": "^1.0.1",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0",
+                "has-symbols": "^1.1.0",
                 "object-keys": "^1.1.1"
             }
         },
@@ -16838,6 +17283,21 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.19.1"
             }
+        },
+        "ofetch": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
+            "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
+            "requires": {
+                "destr": "^2.0.3",
+                "node-fetch-native": "^1.6.4",
+                "ufo": "^1.5.4"
+            }
+        },
+        "ohash": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
+            "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g=="
         },
         "on-exit-leak-free": {
             "version": "0.2.0",
@@ -16981,6 +17441,11 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
+        "pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+        },
         "pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -17002,8 +17467,7 @@
         "picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
         },
         "pidtree": {
             "version": "0.5.0",
@@ -17114,6 +17578,11 @@
                     "dev": true
                 }
             }
+        },
+        "pngjs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+            "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
         },
         "postcss": {
             "version": "8.4.13",
@@ -17240,6 +17709,114 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true
         },
+        "qrcode": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+            "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+            "requires": {
+                "dijkstrajs": "^1.0.1",
+                "encode-utf8": "^1.0.3",
+                "pngjs": "^5.0.0",
+                "yargs": "^15.3.1"
+            },
+            "dependencies": {
+                "cliui": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
+                    }
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+                    "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+                },
+                "yargs": {
+                    "version": "15.4.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                    "requires": {
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
         "qs": {
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -17268,6 +17845,11 @@
             "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
             "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
         },
+        "radix3": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+            "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
+        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -17277,9 +17859,9 @@
             }
         },
         "react": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0"
@@ -17305,7 +17887,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
             "requires": {
                 "picomatch": "^2.2.1"
             }
@@ -17510,9 +18091,9 @@
             }
         },
         "rxjs": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-            "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "requires": {
                 "tslib": "^2.1.0"
             }
@@ -17530,11 +18111,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "safe-json-utils": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-            "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
         },
         "safe-stable-stringify": {
             "version": "2.4.3",
@@ -17586,15 +18162,28 @@
             }
         },
         "semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true
         },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+        },
+        "set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "requires": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            }
         },
         "sha.js": {
             "version": "2.4.11",
@@ -17677,9 +18266,9 @@
             "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw=="
         },
         "sodium-native": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.1.1.tgz",
-            "integrity": "sha512-LXkAfRd4FHtkQS4X6g+nRcVaN7mWVNepV06phIsC6+IZFvGh1voW5TNQiQp2twVaMf05gZqQjuS+uWLM6gHhNQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+            "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
             "optional": true,
             "requires": {
                 "node-gyp-build": "^4.8.0"
@@ -17861,6 +18450,22 @@
                 "randombytes": "^2.1.0",
                 "toml": "^3.0.0",
                 "urijs": "^1.19.1"
+            },
+            "dependencies": {
+                "@stellar/stellar-base": {
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-10.0.1.tgz",
+                    "integrity": "sha512-BDbx7VHOEQh+4J3Q+gStNXgPaNckVFmD4aOlBBGwxlF6vPFmVnW8IoJdkX7T58zpX55eWI6DXvEhDBlrqTlhAQ==",
+                    "requires": {
+                        "@stellar/js-xdr": "^3.0.1",
+                        "base32.js": "^0.1.0",
+                        "bignumber.js": "^9.1.2",
+                        "buffer": "^6.0.3",
+                        "sha.js": "^2.3.6",
+                        "sodium-native": "^4.0.1",
+                        "tweetnacl": "^1.0.3"
+                    }
+                }
             }
         },
         "stream-shift": {
@@ -18177,7 +18782,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -18263,9 +18867,9 @@
             }
         },
         "tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "tsutils": {
             "version": "3.21.0",
@@ -18339,6 +18943,11 @@
             "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
             "dev": true
         },
+        "ufo": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+            "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
+        },
         "uint8arrays": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -18358,11 +18967,55 @@
                 "which-boxed-primitive": "^1.0.2"
             }
         },
+        "uncrypto": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+        },
+        "unenv": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
+            "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
+            "requires": {
+                "consola": "^3.2.3",
+                "defu": "^6.1.4",
+                "mime": "^3.0.0",
+                "node-fetch-native": "^1.6.4",
+                "pathe": "^1.1.2"
+            }
+        },
+        "unfetch": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+            "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+        },
         "universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
             "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
             "dev": true
+        },
+        "unstorage": {
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.14.4.tgz",
+            "integrity": "sha512-1SYeamwuYeQJtJ/USE1x4l17LkmQBzg7deBJ+U9qOBoHo15d1cDxG4jM31zKRgF7pG0kirZy4wVMX6WL6Zoscg==",
+            "requires": {
+                "anymatch": "^3.1.3",
+                "chokidar": "^3.6.0",
+                "destr": "^2.0.3",
+                "h3": "^1.13.0",
+                "lru-cache": "^10.4.3",
+                "node-fetch-native": "^1.6.4",
+                "ofetch": "^1.4.1",
+                "ufo": "^1.5.4"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "10.4.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+                    "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+                }
+            }
         },
         "untildify": {
             "version": "4.0.0",
@@ -18391,15 +19044,14 @@
             "requires": {}
         },
         "util": {
-            "version": "0.12.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-            "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
             "requires": {
                 "inherits": "^2.0.3",
                 "is-arguments": "^1.0.4",
                 "is-generator-function": "^1.0.7",
                 "is-typed-array": "^1.1.3",
-                "safe-buffer": "^5.1.2",
                 "which-typed-array": "^1.1.2"
             }
         },
@@ -18440,9 +19092,9 @@
             }
         },
         "valtio": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.0.tgz",
-            "integrity": "sha512-65Yd0yU5qs86b5lN1eu/nzcTgQ9/6YnD6iO+DDaDbQLn1Zv2w12Gwk43WkPlUBxk5wL/6cD5YMFf7kj6HZ1Kpg==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.2.tgz",
+            "integrity": "sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw==",
             "requires": {
                 "proxy-compare": "2.5.1",
                 "use-sync-external-store": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -94,10 +94,10 @@
         "vite": "^2.9.18"
     },
     "dependencies": {
-        "@creit-tech/xbull-wallet-connect": "github:Creit-Tech/xBull-Wallet-Connect",
+        "@creit.tech/xbull-wallet-connect": "^0.3.0",
         "@lobstrco/signer-extension-api": "^1.0.0-beta.0",
         "@stellar/freighter-api": "^1.4.0",
-        "@stellar/stellar-sdk": "^12.3.0",
+        "@stellar/stellar-sdk": "^13.1.0",
         "@walletconnect/modal": "^2.6.1",
         "@walletconnect/sign-client": "^2.9.2",
         "@walletconnect/types": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
         "json5": "^2.2.2",
         "minimist": "^1.2.8",
         "sonarqube-scanner": "^3.4.0",
-        "stellar-sdk": "^11.1.0",
         "util": "^0.12.4"
     }
 }

--- a/src/lib/components/transaction/Signatures.svelte
+++ b/src/lib/components/transaction/Signatures.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { StrKey, xdr } from 'stellar-sdk';
+    import { StrKey, xdr } from '@stellar/stellar-sdk';
 
     import { language } from '../../../store/global';
 

--- a/src/lib/components/transaction/Transaction.svelte
+++ b/src/lib/components/transaction/Transaction.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { FeeBumpTransaction, Transaction, TransactionBuilder, xdr } from 'stellar-sdk';
+    import { FeeBumpTransaction, Transaction, TransactionBuilder, xdr } from '@stellar/stellar-sdk';
     import { createEventDispatcher } from 'svelte';
     import { onMount } from 'svelte';
     import { Link } from 'svelte-navigator';

--- a/src/lib/components/transaction/operations/DynamicOperationComponentFactory.ts
+++ b/src/lib/components/transaction/operations/DynamicOperationComponentFactory.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import InvalidComponentTypeError from '../errors/InvalidComponentTypeError';
 import type { OperationComponent } from './OperationComponent';

--- a/src/lib/components/transaction/operations/InvokeHostFunctionOperationComponentFactory.ts
+++ b/src/lib/components/transaction/operations/InvokeHostFunctionOperationComponentFactory.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import { getContractAddress, getContractMethodsParams } from '../../../soroban/GetContractFunctionInfo';
 import { InvokeHostFunction, InvokeHostFunctionType } from '../../../stellar/InvokeHostFunction';

--- a/src/lib/components/transaction/operations/accountMerge/AccountMergeComponent.ts
+++ b/src/lib/components/transaction/operations/accountMerge/AccountMergeComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/allowTrust/AllowTrustComponent.ts
+++ b/src/lib/components/transaction/operations/allowTrust/AllowTrustComponent.ts
@@ -1,5 +1,5 @@
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 import type { ITranslation } from 'src/lib/i18n/ITranslation';
-import type { Operation, Transaction } from 'stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/beginSponsoringFutureReserves/BeginSponsoringFutureReservesComponent.ts
+++ b/src/lib/components/transaction/operations/beginSponsoringFutureReserves/BeginSponsoringFutureReservesComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/bumpSequence/BumpSequenceComponent.ts
+++ b/src/lib/components/transaction/operations/bumpSequence/BumpSequenceComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/changeTrust/ChangeTrustComponent.ts
+++ b/src/lib/components/transaction/operations/changeTrust/ChangeTrustComponent.ts
@@ -1,5 +1,5 @@
+import { Asset, Operation, Transaction } from '@stellar/stellar-sdk';
 import type { ITranslation } from 'src/lib/i18n/ITranslation';
-import { Asset, Operation, Transaction } from 'stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/claimClaimableBalance/ClaimClaimableBalanceComponent.ts
+++ b/src/lib/components/transaction/operations/claimClaimableBalance/ClaimClaimableBalanceComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/clawback/ClawbackComponent.ts
+++ b/src/lib/components/transaction/operations/clawback/ClawbackComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/clawbackClaimableBalance/ClawbackClaimableBalanceComponent.ts
+++ b/src/lib/components/transaction/operations/clawbackClaimableBalance/ClawbackClaimableBalanceComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/createAccount/CreateAccountComponent.ts
+++ b/src/lib/components/transaction/operations/createAccount/CreateAccountComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/createClaimableBalance/CreateClaimableBalanceComponent.ts
+++ b/src/lib/components/transaction/operations/createClaimableBalance/CreateClaimableBalanceComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/createPassiveSellOffer/CreatePassiveSellOfferComponent.ts
+++ b/src/lib/components/transaction/operations/createPassiveSellOffer/CreatePassiveSellOfferComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/endSponsoringFutureReserves/EndSponsoringFutureReservesComponent.ts
+++ b/src/lib/components/transaction/operations/endSponsoringFutureReserves/EndSponsoringFutureReservesComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/extendFootprint/ExtendFootprintComponent.ts
+++ b/src/lib/components/transaction/operations/extendFootprint/ExtendFootprintComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/liquidityPoolDeposit/LiquidityPoolDepositComponent.ts
+++ b/src/lib/components/transaction/operations/liquidityPoolDeposit/LiquidityPoolDepositComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/liquidityPoolWithdraw/LiquidityPoolWithdrawComponent.ts
+++ b/src/lib/components/transaction/operations/liquidityPoolWithdraw/LiquidityPoolWithdrawComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/manageBuyOffer/ManageBuyOfferComponent.ts
+++ b/src/lib/components/transaction/operations/manageBuyOffer/ManageBuyOfferComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/manageData/ManageDataComponent.ts
+++ b/src/lib/components/transaction/operations/manageData/ManageDataComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/manageSellOffer/ManageSellOfferComponent.ts
+++ b/src/lib/components/transaction/operations/manageSellOffer/ManageSellOfferComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/pathPaymentStrictReceive/PathPaymentStrictReceiveComponent.ts
+++ b/src/lib/components/transaction/operations/pathPaymentStrictReceive/PathPaymentStrictReceiveComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/pathPaymentStrictSend/PathPaymentStrictSendComponent.ts
+++ b/src/lib/components/transaction/operations/pathPaymentStrictSend/PathPaymentStrictSendComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/payment/PaymentComponent.ts
+++ b/src/lib/components/transaction/operations/payment/PaymentComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation as OperationType, Transaction } from 'stellar-sdk';
+import type { Operation as OperationType, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/restoreFootprint/RestoreFootprintComponent.ts
+++ b/src/lib/components/transaction/operations/restoreFootprint/RestoreFootprintComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/revokeAccountSponsorship/RevokeAccountSponsorshipComponent.ts
+++ b/src/lib/components/transaction/operations/revokeAccountSponsorship/RevokeAccountSponsorshipComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/revokeClaimableBalanceSponsorship/RevokeClaimableBalanceSponsorshipComponent.ts
+++ b/src/lib/components/transaction/operations/revokeClaimableBalanceSponsorship/RevokeClaimableBalanceSponsorshipComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/revokeDataSponsorship/RevokeDataSponsorshipComponent.ts
+++ b/src/lib/components/transaction/operations/revokeDataSponsorship/RevokeDataSponsorshipComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/revokeLiquidityPoolSponsorship/RevokeLiquidityPoolSponsorshipComponent.ts
+++ b/src/lib/components/transaction/operations/revokeLiquidityPoolSponsorship/RevokeLiquidityPoolSponsorshipComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/revokeOfferSponsorship/RevokeOfferSponsorshipComponent.ts
+++ b/src/lib/components/transaction/operations/revokeOfferSponsorship/RevokeOfferSponsorshipComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/revokeSignerSponsorship/RevokeSignerSponsorshipComponent.ts
+++ b/src/lib/components/transaction/operations/revokeSignerSponsorship/RevokeSignerSponsorshipComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/revokeSignerSponsorship/revokeSignerHelper.ts
+++ b/src/lib/components/transaction/operations/revokeSignerSponsorship/revokeSignerHelper.ts
@@ -1,4 +1,4 @@
-import { SignerKeyOptions, StrKey } from 'stellar-sdk';
+import { SignerKeyOptions, StrKey } from '@stellar/stellar-sdk';
 
 import InvalidSignerTypeError from '../../errors/InvalidSignerTypeError';
 

--- a/src/lib/components/transaction/operations/revokeTrustLineSponsorship/RevokeTrustLineSponsorshipComponent.ts
+++ b/src/lib/components/transaction/operations/revokeTrustLineSponsorship/RevokeTrustLineSponsorshipComponent.ts
@@ -1,4 +1,4 @@
-import { Asset, Operation, Transaction } from 'stellar-sdk';
+import { Asset, Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/setOptions/SetOptionsComponent.ts
+++ b/src/lib/components/transaction/operations/setOptions/SetOptionsComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/components/transaction/operations/setOptions/setOptionsHelper.ts
+++ b/src/lib/components/transaction/operations/setOptions/setOptionsHelper.ts
@@ -1,4 +1,4 @@
-import { Operation, StrKey } from 'stellar-sdk';
+import { Operation, StrKey } from '@stellar/stellar-sdk';
 
 export default function getValue(operation: Operation.SetOptions) {
     if (operation.signer) {

--- a/src/lib/components/transaction/operations/setTrustLineFlags/SetTrustLineFlagsComponent.ts
+++ b/src/lib/components/transaction/operations/setTrustLineFlags/SetTrustLineFlagsComponent.ts
@@ -1,4 +1,4 @@
-import type { Operation, Transaction } from 'stellar-sdk';
+import type { Operation, Transaction } from '@stellar/stellar-sdk';
 
 import AbstractOperationComponent from '../AbstractOperationComponent';
 import type IOperationComponent from '../IOperationComponent';

--- a/src/lib/soroban/GetContractFunctionInfo.ts
+++ b/src/lib/soroban/GetContractFunctionInfo.ts
@@ -1,4 +1,4 @@
-import { Address, Contract, SorobanRpc, StrKey, xdr } from '@stellar/stellar-sdk';
+import { Address, Contract, rpc as SorobanRpc, StrKey, xdr } from '@stellar/stellar-sdk';
 import { Buffer } from 'buffer';
 
 import type { ContractFunctionInfo, InputInfo } from './ContractFunctionInfo.interface';

--- a/src/lib/soroban/utils/index.ts
+++ b/src/lib/soroban/utils/index.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc } from '@stellar/stellar-sdk';
+import { rpc as SorobanRpc } from '@stellar/stellar-sdk';
 
 import { SOROBANRPC_URL } from '../../../constants';
 

--- a/src/lib/stellar/Payment.ts
+++ b/src/lib/stellar/Payment.ts
@@ -1,4 +1,4 @@
-import { Asset, BASE_FEE, Operation, TransactionBuilder } from 'stellar-sdk';
+import { Asset, BASE_FEE, Operation, TransactionBuilder } from '@stellar/stellar-sdk';
 
 import { CURRENT_NETWORK_PASSPHRASE } from './StellarNetwork';
 import { server } from './utils';

--- a/src/lib/stellar/utils/index.ts
+++ b/src/lib/stellar/utils/index.ts
@@ -1,4 +1,4 @@
-import { Horizon } from 'stellar-sdk';
+import { Horizon } from '@stellar/stellar-sdk';
 
 import { HORIZON_URL } from '../../../constants';
 

--- a/src/lib/wallets/AbstractWallet.ts
+++ b/src/lib/wallets/AbstractWallet.ts
@@ -1,4 +1,4 @@
-import type { Transaction } from 'stellar-sdk';
+import type { Transaction } from '@stellar/stellar-sdk';
 import type { ComponentType } from 'svelte';
 
 import NotImplementedError from '../errors/NotImplementedError';

--- a/src/lib/wallets/IWallet.ts
+++ b/src/lib/wallets/IWallet.ts
@@ -1,4 +1,4 @@
-import type { FeeBumpTransaction, Transaction } from 'stellar-sdk';
+import type { FeeBumpTransaction, Transaction } from '@stellar/stellar-sdk';
 import type { ComponentType } from 'svelte';
 
 export default interface IWallet {

--- a/src/lib/wallets/albedo/Albedo.ts
+++ b/src/lib/wallets/albedo/Albedo.ts
@@ -1,4 +1,4 @@
-import type { FeeBumpTransaction, Transaction } from 'stellar-sdk';
+import type { FeeBumpTransaction, Transaction } from '@stellar/stellar-sdk';
 
 import { AlbedoIcon } from '../../../assets';
 import { CURRENT_STELLAR_NETWORK, StellarNetwork } from '../../stellar/StellarNetwork';

--- a/src/lib/wallets/freighter/Freighter.ts
+++ b/src/lib/wallets/freighter/Freighter.ts
@@ -1,5 +1,5 @@
 import { getPublicKey, isConnected, signTransaction } from '@stellar/freighter-api';
-import type { FeeBumpTransaction, Transaction } from 'stellar-sdk';
+import type { FeeBumpTransaction, Transaction } from '@stellar/stellar-sdk';
 
 import { FreighterIcon } from '../../../assets';
 import { CURRENT_STELLAR_NETWORK, StellarNetwork } from '../../stellar/StellarNetwork';

--- a/src/lib/wallets/freighter/__test__/freighter.test.ts
+++ b/src/lib/wallets/freighter/__test__/freighter.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { expect } from '@jest/globals';
 import { signTransaction } from '@stellar/freighter-api';
-import * as StellarSdk from 'stellar-sdk';
+import * as StellarSdk from '@stellar/stellar-sdk';
 
 import { StellarNetwork } from '../../../stellar/StellarNetwork';
 import LocalStorage from '../../../storage/storage';
@@ -22,7 +22,7 @@ jest.mock('@stellar/freighter-api', () => ({
     signTransaction: jest.fn(),
 }));
 
-jest.mock('stellar-sdk', () => {
+jest.mock('@stellar/stellar-sdk', () => {
     return {
         Transaction: jest.fn().mockImplementation(() => mockTx),
         Networks: {

--- a/src/lib/wallets/lobstr/Lobstr.ts
+++ b/src/lib/wallets/lobstr/Lobstr.ts
@@ -1,5 +1,5 @@
 import { getPublicKey, isConnected, signTransaction } from '@lobstrco/signer-extension-api';
-import type { FeeBumpTransaction, Transaction } from 'stellar-sdk';
+import type { FeeBumpTransaction, Transaction } from '@stellar/stellar-sdk';
 
 import { LobstrIcon } from '../../../assets';
 import { StellarNetwork } from '../../stellar/StellarNetwork';

--- a/src/lib/wallets/lobstr/__test__/lobstr.test.ts
+++ b/src/lib/wallets/lobstr/__test__/lobstr.test.ts
@@ -38,7 +38,7 @@ jest.mock('@lobstrco/signer-extension-api', () => ({
     signTransaction: jest.fn(),
 }));
 
-jest.mock('stellar-sdk', () => {
+jest.mock('@stellar/stellar-sdk', () => {
     return {
         Transaction: jest.fn().mockImplementation(() => mockTx),
         Networks: {

--- a/src/lib/wallets/privateKey/PrivateKey.ts
+++ b/src/lib/wallets/privateKey/PrivateKey.ts
@@ -1,5 +1,5 @@
-import type { FeeBumpTransaction, Transaction } from 'stellar-sdk';
-import { Keypair } from 'stellar-sdk';
+import type { FeeBumpTransaction, Transaction } from '@stellar/stellar-sdk';
+import { Keypair } from '@stellar/stellar-sdk';
 
 import { PrivateKeyIcon } from '../../../assets';
 import type IDecryptableValue from '../../security/IDecryptableValue';

--- a/src/lib/wallets/privateKey/__test__/privateKey.test.ts
+++ b/src/lib/wallets/privateKey/__test__/privateKey.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { expect } from '@jest/globals';
-import StellarSdk from 'stellar-sdk';
+import StellarSdk from '@stellar/stellar-sdk';
 import { TextDecoder, TextEncoder } from 'util';
 
 import LocalStorage from '../../../storage/storage';
@@ -20,7 +20,7 @@ const mockTx = {
     toXDR: jest.fn(),
 };
 
-jest.mock('stellar-sdk', () => {
+jest.mock('@stellar/stellar-sdk', () => {
     return {
         Keypair: {
             fromSecret: jest.fn(),

--- a/src/lib/wallets/rabet/Rabet.ts
+++ b/src/lib/wallets/rabet/Rabet.ts
@@ -1,4 +1,4 @@
-import type { FeeBumpTransaction, Transaction } from 'stellar-sdk';
+import type { FeeBumpTransaction, Transaction } from '@stellar/stellar-sdk';
 
 import { RabetIcon } from '../../../assets';
 import { CURRENT_STELLAR_NETWORK, StellarNetwork } from '../../stellar/StellarNetwork';

--- a/src/lib/wallets/walletConnect/WalletConnect.ts
+++ b/src/lib/wallets/walletConnect/WalletConnect.ts
@@ -1,6 +1,6 @@
+import type { FeeBumpTransaction, Transaction } from '@stellar/stellar-sdk';
 import type { SessionTypes } from '@walletconnect/types';
 import type IStorage from 'src/lib/storage/IStorage';
-import type { FeeBumpTransaction, Transaction } from 'stellar-sdk';
 
 import { WalletConnectIcon } from '../../../assets';
 import { NoPublicKeyError } from '../../errors/WalletConnectErrors';

--- a/src/lib/wallets/xBull/XBull.ts
+++ b/src/lib/wallets/xBull/XBull.ts
@@ -1,8 +1,8 @@
-import { xBullWalletConnect } from '@creit-tech/xbull-wallet-connect';
-import type { FeeBumpTransaction, Transaction } from 'stellar-sdk';
+import { xBullWalletConnect } from '@creit.tech/xbull-wallet-connect';
+import type { FeeBumpTransaction, Transaction } from '@stellar/stellar-sdk';
 
 import { XBullIcon } from '../../../assets';
-import { CURRENT_STELLAR_NETWORK, StellarNetwork } from '../../stellar/StellarNetwork';
+import { CURRENT_NETWORK_PASSPHRASE, CURRENT_STELLAR_NETWORK, StellarNetwork } from '../../stellar/StellarNetwork';
 import type IStorage from '../../storage/IStorage';
 import AbstractWallet from '../AbstractWallet';
 import type IWallet from '../IWallet';
@@ -35,7 +35,10 @@ export default class XBull extends AbstractWallet implements IWallet {
 
     public override async sign(tx: Transaction | FeeBumpTransaction): Promise<string> {
         const bridge = new xBullWalletConnect();
-        const signedXdr = await bridge.sign({ xdr: tx.toXDR(), network: this.XBullNetwork });
+        const signedXdr = await bridge.sign({
+            xdr: tx.toXDR(),
+            network: CURRENT_NETWORK_PASSPHRASE,
+        });
         bridge.closeConnections();
         return signedXdr;
     }

--- a/src/lib/wallets/xBull/__test__/xBull.test.ts
+++ b/src/lib/wallets/xBull/__test__/xBull.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@jest/globals';
-import * as StellarSdk from 'stellar-sdk';
+import * as StellarSdk from '@stellar/stellar-sdk';
 
 import { StellarNetwork } from '../../../stellar/StellarNetwork';
 import LocalStorage from '../../../storage/storage';
@@ -7,6 +7,7 @@ import XBull from '../XBull';
 
 const signedXdr =
     'AAAAAgAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAGQAATOSAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAA2jYMwhev3yM7P+JWOv6kRQZAssek5zytAbbyhJbOjNQAAAAAF9eEAAAAAAAAAAAA=';
+const networkPassphrase = 'Test SDF Future Network ; October 2022';
 const mockTx = {
     sign: jest.fn(),
     toXDR: jest.fn().mockReturnValue(signedXdr),
@@ -14,9 +15,10 @@ const mockTx = {
 
 jest.mock('../../../../constants', () => ({
     STELLAR_NETWORK: 'futurenet',
+    HORIZON_NETWORK_PASSPHRASE: 'Test SDF Future Network ; October 2022',
 }));
 
-jest.mock('stellar-sdk', () => {
+jest.mock('@stellar/stellar-sdk', () => {
     return {
         Transaction: jest.fn().mockImplementation(() => mockTx),
         Networks: {
@@ -30,7 +32,7 @@ const mockBridge = {
     closeConnections: jest.fn(),
 };
 
-jest.mock('@creit-tech/xbull-wallet-connect', () => {
+jest.mock('@creit.tech/xbull-wallet-connect', () => {
     return {
         xBullWalletConnect: jest.fn().mockImplementationOnce(() => mockBridge),
     };
@@ -57,6 +59,6 @@ describe('xBull management', () => {
         expect(result).toBe(responseXdr);
         expect(xBull.XBullNetwork).toEqual(xBullNetwork);
         expect(mockBridge.sign).toHaveBeenCalledTimes(1);
-        expect(mockBridge.sign).toHaveBeenLastCalledWith({ xdr: signedXdr, network: xBullNetwork });
+        expect(mockBridge.sign).toHaveBeenLastCalledWith({ xdr: signedXdr, network: networkPassphrase });
     });
 });


### PR DESCRIPTION
# Summary
This PR aims to replace the deprecated Stellar SDK dependency with the new supported one, and also update the dependency needed to create a bridge with XBull since it has changed its base repository and requires different properties to open the signature window.

# Details
- Replace `stellar-sdk` with the `@stellar/stellar-sdk` dependency as the latter has been deprecated by Stellar.
- Update `xbull-wallet-connect` dependency as its creator now has a different repository with the latest version.
- Update soroban rpc import due to change in `@stellar/stellar-sdk`.