### PR TITLE
fix: Modify base property in vite config 

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    base: './',
+    base: '/',
     plugins: [svelte()],
     resolve: {
         alias: {


### PR DESCRIPTION
# Summary

- Modify `base` property in vite config. to use absolute paths instead of relatives. 